### PR TITLE
Fix: Pin Docker base image versions for reproducibility

### DIFF
--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,5 +1,6 @@
 # Custom Caddy with Cloudflare DNS plugin
-FROM caddybuilds/caddy-cloudflare:latest
+# Pinned to v2.10.2 for reproducibility and security
+FROM caddybuilds/caddy-cloudflare:2.10.2
 
 # Add any custom Caddy modules or configuration here
 # Example: COPY custom-plugins /usr/local/bin/

--- a/docker/grafana/Dockerfile
+++ b/docker/grafana/Dockerfile
@@ -1,5 +1,6 @@
 # Custom Grafana with pre-installed plugins
-FROM grafana/grafana:latest
+# Pinned to v12.3.0 for reproducibility and security
+FROM grafana/grafana:12.3.0
 
 # Switch to root to install plugins
 USER root

--- a/docker/loki/Dockerfile
+++ b/docker/loki/Dockerfile
@@ -1,5 +1,6 @@
 # Custom Loki with pre-configured settings
-FROM grafana/loki:latest
+# Pinned to v3.6.0 for reproducibility and security
+FROM grafana/loki:3.6.0
 
 # Add custom loki-config.yaml if you want a default configuration
 # Note: Terraform can also inject this configuration at runtime

--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,5 +1,6 @@
 # Custom Prometheus with pre-configured settings
-FROM prom/prometheus:latest
+# Pinned to v3.7.3 for reproducibility and security
+FROM prom/prometheus:v3.7.3
 
 # Add custom prometheus.yml if you want a default configuration
 # Note: Terraform can also inject this configuration at runtime


### PR DESCRIPTION
## Summary

This PR addresses issue #11 by pinning all Docker base image versions to specific stable releases instead of using `:latest` tags.

### Changes Made

- **Caddy**: Pinned to `v2.10.2` (caddybuilds/caddy-cloudflare)
- **Grafana**: Pinned to `v12.3.0`
- **Loki**: Pinned to `v3.6.0`
- **Prometheus**: Pinned to `v3.7.3`

### Benefits

✅ **Reproducible builds** - Same Dockerfile will always produce the same image
✅ **Predictable updates** - Breaking changes won't appear unexpectedly
✅ **Security control** - Deliberate version upgrades with testing
✅ **Easier rollbacks** - Can revert to known-good versions
✅ **CI/CD stability** - Pipeline produces consistent results

### Version Selection

All versions were selected based on the latest stable releases as of November 2025:
- Caddy v2.10.2 (released August 23, 2025)
- Grafana v12.3.0 (released November 19, 2025)
- Loki v3.6.0 (released November 17, 2025)
- Prometheus v3.7.3 (released October 29, 2025)

### Testing

The changes update only the Dockerfile `FROM` directives. Since the images are published to GitHub Container Registry via CI/CD, the next push to `main` or `develop` will build new images with these pinned versions.

### Future Considerations

Consider setting up automated dependency updates with:
- Dependabot for Docker base images
- Renovate bot for automated PR creation
- Scheduled CI runs to test new upstream versions

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)