### PR TITLE
Fix: Configure Dependabot for Docker base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,58 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
+# Dependabot Configuration
+# Automatically creates PRs for dependency updates
+# Documentation: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  # DevContainer updates
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"
+      - "devcontainer"
+
+  # Docker base image updates
+  # Creates PRs when new versions of base images are released
+  # Each image is tracked separately for granular control
+
+  - package-ecosystem: "docker"
+    directory: "/docker/caddy"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "caddy"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/grafana"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "grafana"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/loki"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "loki"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/prometheus"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "prometheus"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,41 @@ When creating a PR, please include:
 - Keep PRs focused and reasonably sized
 - Be respectful and constructive in reviews
 
+### Reviewing Dependabot PRs
+
+Dependabot automatically creates PRs for Docker base image updates. When reviewing these:
+
+**1. Check the changelog:**
+- Review the upstream release notes for the new version
+- Look for breaking changes or security fixes
+- Verify compatibility with our configuration
+
+**2. Verify CI passes:**
+- Ensure all CI checks pass (build, terraform validate)
+- Review any test failures carefully
+
+**3. Test locally (for major updates):**
+```bash
+# Pull the PR branch
+gh pr checkout <pr-number>
+
+# Build the updated image locally
+make build-<service>
+
+# Test with Terraform
+make terraform-plan
+```
+
+**4. Merge strategy:**
+- **Patch updates (x.x.N)**: Usually safe to merge after CI passes
+- **Minor updates (x.N.x)**: Review changelog, merge if no breaking changes
+- **Major updates (N.x.x)**: Test thoroughly, may require configuration changes
+
+**5. Post-merge:**
+- Monitor deployed services for issues
+- Roll back if problems are detected
+- Update documentation if configuration changed
+
 ## Release Process
 
 1. **Develop** - Continuous integration, all features merged here


### PR DESCRIPTION
## Summary

Configures GitHub Dependabot to automatically create PRs when new versions of Docker base images are released.

## Changes

### .github/dependabot.yml
- Added Docker ecosystem tracking for all four service images
- Weekly update checks with max 5 concurrent PRs per service
- Auto-labeling with `dependencies`, `docker`, and service-specific labels
- Builds on existing devcontainer update configuration

**Images tracked:**
- Caddy: `caddybuilds/caddy-cloudflare:2.10.2`
- Grafana: `grafana/grafana:12.3.0`
- Loki: `grafana/loki:3.6.0`
- Prometheus: `prom/prometheus:v3.7.3`

### CONTRIBUTING.md
- Added section on reviewing Dependabot PRs
- Includes merge strategies for patch/minor/major updates
- Testing steps for validating image updates
- Post-merge monitoring guidelines

## Benefits

✅ **Security**: Automated notifications of new upstream releases
✅ **Maintenance**: Reduces manual effort in tracking updates
✅ **Testing**: Each update PR validated by CI/CD before merging
✅ **Transparency**: Clear changelog of version updates
✅ **Controlled**: Maintainers still review and approve changes

## Testing

- Validated YAML syntax
- Confirmed all Dockerfiles have pinned versions
- Verified directory paths match repository structure

## Next Steps

Once merged:
1. Dependabot will begin weekly checks for new image versions
2. PRs will be automatically created when updates are available
3. Follow review guidelines in CONTRIBUTING.md for each PR
4. CI will validate all changes before merging

Fixes #27