### PR TITLE
improve: optimize CI Docker workflow with selective builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
   detect-changes:
     name: Detect Changed Images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       caddy: ${{ steps.filter.outputs.caddy }}
       grafana: ${{ steps.filter.outputs.grafana }}


### PR DESCRIPTION
## Summary
- Add path-based change detection using `dorny/paths-filter` action
- Only build and test changed Docker images on push to main/develop
- Build all images for PRs to ensure compatibility testing
- Simplify tagging strategy:
  - `main` branch → `latest` tag (production)
  - `develop` branch → `develop` tag
  - Both get SHA tags for traceability
- Consolidate duplicate build/test jobs into single conditional jobs
- Add documentation note about setting packages to public visibility

## Behavior
| Event | Images Built |
|-------|-------------|
| PR | All 4 images (ensures compatibility) |
| Push to develop/main | Only changed images |
| Terraform-only changes | No Docker builds |

## Package Visibility Note
GitHub packages are private by default. To allow Incus to pull images without authentication, each package must be manually set to public visibility in GitHub settings (one-time setup per package).

## Test plan
- [ ] Verify PR builds all 4 images
- [ ] Verify push with single Dockerfile change only builds that image
- [ ] Verify tagging is correct for develop and main branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)