### PR TITLE
fix: set initial ownership on storage volumes for OCI containers

### DIFF
--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -6,6 +6,11 @@ resource "incus_storage_volume" "grafana_data" {
 
   config = {
     size = var.data_volume_size
+    # Set initial ownership for Grafana user (UID 472) to allow writes from non-root container
+    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+    "initial.uid"  = "472"
+    "initial.gid"  = "472"
+    "initial.mode" = "0755"
   }
 
   content_type = "filesystem"
@@ -17,9 +22,6 @@ resource "incus_profile" "grafana" {
   config = {
     "limits.cpu"    = var.cpu_limit
     "limits.memory" = var.memory_limit
-    # OCI containers running as non-root need privileged mode to write to mounted volumes
-    # because security.shifted doesn't work for OCI/application containers on ZFS
-    "security.privileged" = "true"
   }
 
   device {

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -6,6 +6,11 @@ resource "incus_storage_volume" "loki_data" {
 
   config = {
     size = var.data_volume_size
+    # Set initial ownership for Loki user (UID 10001) to allow writes from non-root container
+    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+    "initial.uid"  = "10001"
+    "initial.gid"  = "10001"
+    "initial.mode" = "0755"
   }
 
   content_type = "filesystem"
@@ -17,9 +22,6 @@ resource "incus_profile" "loki" {
   config = {
     "limits.cpu"    = var.cpu_limit
     "limits.memory" = var.memory_limit
-    # OCI containers running as non-root need privileged mode to write to mounted volumes
-    # because security.shifted doesn't work for OCI/application containers on ZFS
-    "security.privileged" = "true"
   }
 
   device {

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -6,6 +6,11 @@ resource "incus_storage_volume" "prometheus_data" {
 
   config = {
     size = var.data_volume_size
+    # Set initial ownership for Prometheus user (UID 65534/nobody) to allow writes from non-root container
+    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+    "initial.uid"  = "65534"
+    "initial.gid"  = "65534"
+    "initial.mode" = "0755"
   }
 
   content_type = "filesystem"
@@ -17,9 +22,6 @@ resource "incus_profile" "prometheus" {
   config = {
     "limits.cpu"    = var.cpu_limit
     "limits.memory" = var.memory_limit
-    # OCI containers running as non-root need privileged mode to write to mounted volumes
-    # because security.shifted doesn't work for OCI/application containers on ZFS
-    "security.privileged" = "true"
   }
 
   device {


### PR DESCRIPTION
## Summary
- Use `initial.uid`, `initial.gid`, and `initial.mode` on storage volumes to set correct ownership at creation time
- Apply fix to all OCI containers with mounted storage volumes: Loki, Grafana, and Prometheus
- Remove `security.privileged=true` from profiles (no longer needed)

## Root Cause
OCI containers running as non-root users cannot write to mounted storage volumes because the volume root directory is created with root:root ownership by default.

## Solution
Incus 6.8+ added `initial.uid`, `initial.gid`, and `initial.mode` configuration options for storage volumes. These set the ownership and permissions of the volume root directory at creation time.

**Volume ownership by container:**
| Container | UID | GID | User |
|-----------|-----|-----|------|
| Loki | 10001 | 10001 | loki |
| Grafana | 472 | 472 | grafana |
| Prometheus | 65534 | 65534 | nobody |

## Previous Attempts (Did Not Work)
1. `security.shifted=true` on storage volumes - doesn't work for OCI containers
2. `security.privileged=true` on profiles - workaround but still had issues

## Testing
**Important:** Existing storage volumes need to be recreated for the new ownership to take effect.

```bash
# Delete existing volumes (will lose data)
incus storage volume delete local loki01-data
incus storage volume delete local grafana01-data
incus storage volume delete local prometheus01-data

# Apply terraform to recreate with correct ownership
make deploy
```

## References
- [Incus 6.8 Release Notes](https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
- [GitHub Issue #1382 - Add ability to set the initial owner of a custom volume](https://github.com/lxc/incus/issues/1382)

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)