### PR TITLE
refactor: use generic profile names for consistency

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,7 @@ module "grafana01" {
   source = "./modules/grafana"
 
   instance_name = "grafana01"
-  profile_name  = "grafana01"
+  profile_name  = "grafana"
 
   # Network configuration - use management network for internal services
   network_name = incus_network.management.name
@@ -75,7 +75,7 @@ module "loki01" {
   source = "./modules/loki"
 
   instance_name = "loki01"
-  profile_name  = "loki01"
+  profile_name  = "loki"
 
   # Network configuration - use management network for internal services
   network_name = incus_network.management.name
@@ -106,7 +106,7 @@ module "prometheus01" {
   source = "./modules/prometheus"
 
   instance_name = "prometheus01"
-  profile_name  = "prometheus01"
+  profile_name  = "prometheus"
 
   # Network configuration - use management network for internal services
   network_name = incus_network.management.name


### PR DESCRIPTION
## Summary
- Change profile names from instance-specific to generic names
- Before: `grafana01`, `loki01`, `prometheus01`
- After: `grafana`, `loki`, `prometheus`

This matches the existing `caddy` profile naming convention and allows profiles to be reused across multiple instances of the same service type if needed.

## Migration
After merging, run `make deploy` which will:
1. Create new profiles with generic names
2. Update containers to use the new profiles
3. Old profiles (`grafana01`, `loki01`, `prometheus01`) can be manually deleted

```bash
# After deploy, clean up old profiles
incus profile delete grafana01
incus profile delete loki01
incus profile delete prometheus01
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)