### PR TITLE
fix: enforce hard memory limits for containers

### DIFF
--- a/terraform/modules/caddy/main.tf
+++ b/terraform/modules/caddy/main.tf
@@ -2,8 +2,10 @@ resource "incus_profile" "caddy" {
   name = var.profile_name
 
   config = {
-    "limits.cpu"    = var.cpu_limit
-    "limits.memory" = var.memory_limit
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+    "boot.autorestart"      = "true"
   }
 
   device {

--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -20,8 +20,10 @@ resource "incus_profile" "grafana" {
   name = var.profile_name
 
   config = {
-    "limits.cpu"    = var.cpu_limit
-    "limits.memory" = var.memory_limit
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+    "boot.autorestart"      = "true"
   }
 
   device {

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -20,8 +20,10 @@ resource "incus_profile" "loki" {
   name = var.profile_name
 
   config = {
-    "limits.cpu"    = var.cpu_limit
-    "limits.memory" = var.memory_limit
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+    "boot.autorestart"      = "true"
   }
 
   device {

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -20,8 +20,10 @@ resource "incus_profile" "prometheus" {
   name = var.profile_name
 
   config = {
-    "limits.cpu"    = var.cpu_limit
-    "limits.memory" = var.memory_limit
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+    "boot.autorestart"      = "true"
   }
 
   device {


### PR DESCRIPTION
## Summary
- Add `limits.memory.enforce = "hard"` to all container profiles (Caddy, Grafana, Loki, Prometheus)
- Add `boot.autorestart = "true"` to automatically restart containers if OOM-killed
- Prevents containers from exceeding their allocated memory limits
- Improves resource isolation and host stability

## Configuration Added

| Setting | Value | Effect |
|---------|-------|--------|
| `limits.memory.enforce` | `hard` | Container killed if exceeding memory limit |
| `boot.autorestart` | `true` | Auto-restart on unexpected exit (up to 10/min) |

## Test plan
- [ ] Verify `tofu plan` shows profile config changes
- [ ] Apply changes and confirm profiles are updated
- [ ] Optionally test OOM behavior with stress tool

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)