### PR TITLE
fix: enable selective Docker builds on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - develop
+      - 'feature/**'
+      - 'fix/**'
+      - 'docs/**'
     paths:
       - 'terraform/**.tf'
       - 'terraform/**.tftpl'
@@ -78,11 +81,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Fetch full history for proper change detection on feature branches
+          fetch-depth: 0
 
       - name: Detect changes
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # For push events, compare against the previous commit (not default branch)
+          # This ensures feature branches only build what changed in that push
+          base: ${{ github.event.before }}
           filters: |
             caddy:
               - 'docker/caddy/**'
@@ -143,7 +152,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -167,20 +176,22 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./docker/${{ matrix.service }}
-          push: ${{ github.event_name == 'push' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ github.event_name == 'push' && steps.meta.outputs.tags || format('test-{0}:latest', matrix.service) }}
+          # Only push to registry from main/develop branches
+          push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+          # Load locally for PRs and feature branches (for testing)
+          load: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/docs/') }}
+          tags: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.meta.outputs.tags || format('test-{0}:latest', matrix.service) }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
       - name: Verify Image
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "${{ github.ref }}" == "refs/heads/main" ] || [ "${{ github.ref }}" == "refs/heads/develop" ]; then
             echo "✅ ${{ matrix.service }} image built and pushed!"
             echo "Tags: ${{ steps.meta.outputs.tags }}"
           else
-            echo "✅ ${{ matrix.service }} image built successfully!"
+            echo "✅ ${{ matrix.service }} image built successfully (not pushed - feature branch or PR)"
           fi
 
   # Test Docker images


### PR DESCRIPTION
## Summary

- Trigger CI on push to `feature/*`, `fix/*`, `docs/*` branches
- Configure paths-filter with `fetch-depth: 0` and `base: github.event.before` to properly detect changes in feature branch pushes (comparing against previous commit, not default branch)
- Only push images to ghcr.io from main/develop branches
- Load images locally on feature branches for testing
- PRs still build all images for final validation before merge

This enables faster CI feedback during development by only building/testing the Docker images that actually changed.

## Test plan

- [x] Pushed to feature branch with only CI workflow changes - Docker build/test jobs were skipped (completed in 16s vs 1m49s)
- [ ] Create PR and verify all Docker images are built (full validation)
- [ ] Merge to develop and verify only changed images are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)