### PR TITLE
feat: add input validation for Terraform variables

### DIFF
--- a/terraform/modules/caddy/variables.tf
+++ b/terraform/modules/caddy/variables.tf
@@ -18,12 +18,22 @@ variable "cpu_limit" {
   description = "CPU limit for the container"
   type        = string
   default     = "2"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
 }
 
 variable "memory_limit" {
   description = "Memory limit for the container"
   type        = string
   default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '512MB' or '2GB'"
+  }
 }
 
 variable "storage_pool" {
@@ -54,6 +64,11 @@ variable "cloudflare_api_token" {
   description = "Cloudflare API token for DNS management"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.cloudflare_api_token) >= 40
+    error_message = "Cloudflare API token appears invalid (must be at least 40 characters)"
+  }
 }
 
 variable "service_blocks" {

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -18,12 +18,22 @@ variable "cpu_limit" {
   description = "CPU limit for the container"
   type        = string
   default     = "2"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
 }
 
 variable "memory_limit" {
   description = "Memory limit for the container"
   type        = string
   default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '512MB' or '2GB'"
+  }
 }
 
 variable "storage_pool" {
@@ -60,6 +70,11 @@ variable "data_volume_size" {
   description = "Size of the storage volume (e.g., 10GB)"
   type        = string
   default     = "10GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
+    error_message = "Volume size must be in format like '10GB' or '100MB'"
+  }
 }
 
 variable "domain" {
@@ -72,11 +87,21 @@ variable "allowed_ip_range" {
   description = "IP range allowed to access Grafana (CIDR notation)"
   type        = string
   default     = "192.168.68.0/22"
+
+  validation {
+    condition     = can(cidrhost(var.allowed_ip_range, 0))
+    error_message = "Must be valid CIDR notation (e.g., 192.168.68.0/22)"
+  }
 }
 
 variable "grafana_port" {
   description = "Port that Grafana listens on"
   type        = string
   default     = "3000"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.grafana_port)) && tonumber(var.grafana_port) >= 1 && tonumber(var.grafana_port) <= 65535
+    error_message = "Port must be a number between 1 and 65535"
+  }
 }
 

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -18,12 +18,22 @@ variable "cpu_limit" {
   description = "CPU limit for the container"
   type        = string
   default     = "2"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
 }
 
 variable "memory_limit" {
   description = "Memory limit for the container"
   type        = string
   default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '512MB' or '2GB'"
+  }
 }
 
 variable "storage_pool" {
@@ -60,10 +70,20 @@ variable "data_volume_size" {
   description = "Size of the storage volume (e.g., 50GB)"
   type        = string
   default     = "50GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
+    error_message = "Volume size must be in format like '50GB' or '100MB'"
+  }
 }
 
 variable "loki_port" {
   description = "Port that Loki listens on"
   type        = string
   default     = "3100"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.loki_port)) && tonumber(var.loki_port) >= 1 && tonumber(var.loki_port) <= 65535
+    error_message = "Port must be a number between 1 and 65535"
+  }
 }

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -18,12 +18,22 @@ variable "cpu_limit" {
   description = "CPU limit for the container"
   type        = string
   default     = "2"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
 }
 
 variable "memory_limit" {
   description = "Memory limit for the container"
   type        = string
   default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '512MB' or '2GB'"
+  }
 }
 
 variable "storage_pool" {
@@ -60,12 +70,22 @@ variable "data_volume_size" {
   description = "Size of the storage volume (e.g., 100GB)"
   type        = string
   default     = "100GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
+    error_message = "Volume size must be in format like '100GB' or '1TB'"
+  }
 }
 
 variable "prometheus_port" {
   description = "Port that Prometheus listens on"
   type        = string
   default     = "9090"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.prometheus_port)) && tonumber(var.prometheus_port) >= 1 && tonumber(var.prometheus_port) <= 65535
+    error_message = "Port must be a number between 1 and 65535"
+  }
 }
 
 variable "prometheus_config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,11 @@ variable "cloudflare_api_token" {
   description = "Cloudflare API token for DNS management"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.cloudflare_api_token) >= 40
+    error_message = "Cloudflare API token appears invalid (must be at least 40 characters)"
+  }
 }
 
 # Grafana Configuration
@@ -21,6 +26,11 @@ variable "development_network_ipv4" {
   description = "IPv4 address for development network"
   type        = string
   default     = "10.10.0.1/24"
+
+  validation {
+    condition     = can(cidrhost(var.development_network_ipv4, 0))
+    error_message = "Must be valid CIDR notation (e.g., 10.10.0.1/24)"
+  }
 }
 
 variable "development_network_nat" {
@@ -35,6 +45,11 @@ variable "testing_network_ipv4" {
   description = "IPv4 address for testing network"
   type        = string
   default     = "10.20.0.1/24"
+
+  validation {
+    condition     = can(cidrhost(var.testing_network_ipv4, 0))
+    error_message = "Must be valid CIDR notation (e.g., 10.20.0.1/24)"
+  }
 }
 
 variable "testing_network_nat" {
@@ -48,6 +63,11 @@ variable "staging_network_ipv4" {
   description = "IPv4 address for staging network"
   type        = string
   default     = "10.30.0.1/24"
+
+  validation {
+    condition     = can(cidrhost(var.staging_network_ipv4, 0))
+    error_message = "Must be valid CIDR notation (e.g., 10.30.0.1/24)"
+  }
 }
 
 variable "staging_network_nat" {
@@ -61,6 +81,11 @@ variable "production_network_ipv4" {
   description = "IPv4 address for production network"
   type        = string
   default     = "10.40.0.1/24"
+
+  validation {
+    condition     = can(cidrhost(var.production_network_ipv4, 0))
+    error_message = "Must be valid CIDR notation (e.g., 10.40.0.1/24)"
+  }
 }
 
 variable "production_network_nat" {
@@ -74,6 +99,11 @@ variable "management_network_ipv4" {
   description = "IPv4 address for management network (monitoring, internal services)"
   type        = string
   default     = "10.50.0.1/24"
+
+  validation {
+    condition     = can(cidrhost(var.management_network_ipv4, 0))
+    error_message = "Must be valid CIDR notation (e.g., 10.50.0.1/24)"
+  }
 }
 
 variable "management_network_nat" {


### PR DESCRIPTION
## Summary

- Add validation blocks for Terraform variables to catch invalid input values early
- Validations include: cloudflare_api_token, network CIDRs, CPU/memory limits, volume sizes, ports, and IP ranges
- Clear error messages help users fix issues quickly

### Variables validated:

| Module | Variables |
|--------|-----------|
| Root | cloudflare_api_token (length >= 40), all network CIDRs |
| Caddy | cpu_limit (1-64), memory_limit (MB/GB), cloudflare_api_token |
| Grafana | cpu_limit, memory_limit, data_volume_size, allowed_ip_range, grafana_port (1-65535) |
| Loki | cpu_limit, memory_limit, data_volume_size, loki_port |
| Prometheus | cpu_limit, memory_limit, data_volume_size, prometheus_port |

## Test plan

- [x] Run `tofu validate` - configuration is valid
- [x] Run `tofu fmt -check -recursive` - formatting passes
- [ ] CI workflow passes

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)