### PR TITLE
feat: add TLS configuration to service Terraform modules (Phase 3)

### DIFF
--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -61,6 +61,16 @@ resource "incus_profile" "grafana" {
   ]
 }
 
+locals {
+  # TLS environment variables (only set when TLS is enabled)
+  tls_env_vars = var.enable_tls ? {
+    ENABLE_TLS         = "true"
+    STEPCA_URL         = var.stepca_url
+    STEPCA_FINGERPRINT = var.stepca_fingerprint
+    CERT_DURATION      = var.cert_duration
+  } : {}
+}
+
 resource "incus_instance" "grafana" {
   name     = var.instance_name
   image    = var.image
@@ -69,5 +79,6 @@ resource "incus_instance" "grafana" {
 
   config = merge(
     { for k, v in var.environment_variables : "environment.${k}" => v },
+    { for k, v in local.tls_env_vars : "environment.${k}" => v },
   )
 }

--- a/terraform/modules/grafana/outputs.tf
+++ b/terraform/modules/grafana/outputs.tf
@@ -27,3 +27,8 @@ output "caddy_config_block" {
     port             = var.grafana_port
   }) : ""
 }
+
+output "tls_enabled" {
+  description = "Whether TLS is enabled for this instance"
+  value       = var.enable_tls
+}

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -105,3 +105,33 @@ variable "grafana_port" {
   }
 }
 
+# TLS Configuration
+variable "enable_tls" {
+  description = "Enable TLS for Grafana using step-ca"
+  type        = bool
+  default     = false
+}
+
+variable "stepca_url" {
+  description = "URL of the step-ca server (required if enable_tls is true)"
+  type        = string
+  default     = ""
+}
+
+variable "stepca_fingerprint" {
+  description = "Fingerprint of the step-ca root certificate (required if enable_tls is true)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cert_duration" {
+  description = "Duration for TLS certificates (e.g., 24h, 168h)"
+  type        = string
+  default     = "24h"
+
+  validation {
+    condition     = can(regex("^[0-9]+h$", var.cert_duration))
+    error_message = "Certificate duration must be in hours format (e.g., '24h', '168h')"
+  }
+}

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -61,6 +61,16 @@ resource "incus_profile" "loki" {
   ]
 }
 
+locals {
+  # TLS environment variables (only set when TLS is enabled)
+  tls_env_vars = var.enable_tls ? {
+    ENABLE_TLS         = "true"
+    STEPCA_URL         = var.stepca_url
+    STEPCA_FINGERPRINT = var.stepca_fingerprint
+    CERT_DURATION      = var.cert_duration
+  } : {}
+}
+
 resource "incus_instance" "loki" {
   name     = var.instance_name
   image    = var.image
@@ -69,5 +79,6 @@ resource "incus_instance" "loki" {
 
   config = merge(
     { for k, v in var.environment_variables : "environment.${k}" => v },
+    { for k, v in local.tls_env_vars : "environment.${k}" => v },
   )
 }

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -20,5 +20,10 @@ output "storage_volume_name" {
 
 output "loki_endpoint" {
   description = "Loki endpoint URL for internal use"
-  value       = "http://${var.instance_name}.incus:${var.loki_port}"
+  value       = "${var.enable_tls ? "https" : "http"}://${var.instance_name}.incus:${var.loki_port}"
+}
+
+output "tls_enabled" {
+  description = "Whether TLS is enabled for this instance"
+  value       = var.enable_tls
 }

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -87,3 +87,34 @@ variable "loki_port" {
     error_message = "Port must be a number between 1 and 65535"
   }
 }
+
+# TLS Configuration
+variable "enable_tls" {
+  description = "Enable TLS for Loki using step-ca"
+  type        = bool
+  default     = false
+}
+
+variable "stepca_url" {
+  description = "URL of the step-ca server (required if enable_tls is true)"
+  type        = string
+  default     = ""
+}
+
+variable "stepca_fingerprint" {
+  description = "Fingerprint of the step-ca root certificate (required if enable_tls is true)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cert_duration" {
+  description = "Duration for TLS certificates (e.g., 24h, 168h)"
+  type        = string
+  default     = "24h"
+
+  validation {
+    condition     = can(regex("^[0-9]+h$", var.cert_duration))
+    error_message = "Certificate duration must be in hours format (e.g., '24h', '168h')"
+  }
+}

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -61,6 +61,16 @@ resource "incus_profile" "prometheus" {
   ]
 }
 
+locals {
+  # TLS environment variables (only set when TLS is enabled)
+  tls_env_vars = var.enable_tls ? {
+    ENABLE_TLS         = "true"
+    STEPCA_URL         = var.stepca_url
+    STEPCA_FINGERPRINT = var.stepca_fingerprint
+    CERT_DURATION      = var.cert_duration
+  } : {}
+}
+
 resource "incus_instance" "prometheus" {
   name     = var.instance_name
   image    = var.image
@@ -69,6 +79,7 @@ resource "incus_instance" "prometheus" {
 
   config = merge(
     { for k, v in var.environment_variables : "environment.${k}" => v },
+    { for k, v in local.tls_env_vars : "environment.${k}" => v },
   )
 
   dynamic "file" {

--- a/terraform/modules/prometheus/outputs.tf
+++ b/terraform/modules/prometheus/outputs.tf
@@ -20,5 +20,10 @@ output "storage_volume_name" {
 
 output "prometheus_endpoint" {
   description = "Prometheus endpoint URL for internal use"
-  value       = "http://${var.instance_name}.incus:${var.prometheus_port}"
+  value       = "${var.enable_tls ? "https" : "http"}://${var.instance_name}.incus:${var.prometheus_port}"
+}
+
+output "tls_enabled" {
+  description = "Whether TLS is enabled for this instance"
+  value       = var.enable_tls
 }

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -93,3 +93,34 @@ variable "prometheus_config" {
   type        = string
   default     = ""
 }
+
+# TLS Configuration
+variable "enable_tls" {
+  description = "Enable TLS for Prometheus using step-ca"
+  type        = bool
+  default     = false
+}
+
+variable "stepca_url" {
+  description = "URL of the step-ca server (required if enable_tls is true)"
+  type        = string
+  default     = ""
+}
+
+variable "stepca_fingerprint" {
+  description = "Fingerprint of the step-ca root certificate (required if enable_tls is true)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cert_duration" {
+  description = "Duration for TLS certificates (e.g., 24h, 168h)"
+  type        = string
+  default     = "24h"
+
+  validation {
+    condition     = can(regex("^[0-9]+h$", var.cert_duration))
+    error_message = "Certificate duration must be in hours format (e.g., '24h', '168h')"
+  }
+}


### PR DESCRIPTION
## Summary

Add TLS variables to Prometheus, Loki, and Grafana Terraform modules for integration with step-ca certificate authority.

### New variables (all services):

| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `enable_tls` | bool | `false` | Enable TLS mode |
| `stepca_url` | string | `""` | URL of the step-ca server |
| `stepca_fingerprint` | string (sensitive) | `""` | CA root certificate fingerprint |
| `cert_duration` | string | `"24h"` | Certificate validity duration |

### Changes:

- Environment variables (`ENABLE_TLS`, `STEPCA_URL`, `STEPCA_FINGERPRINT`, `CERT_DURATION`) are automatically set when `enable_tls=true`
- Endpoint outputs now reflect protocol (http/https) based on TLS mode
- Added `tls_enabled` output for downstream consumers

### Example usage:

```hcl
module "prometheus01" {
  source = "./modules/prometheus"
  
  # Enable TLS with step-ca
  enable_tls         = true
  stepca_url         = module.step_ca01.acme_endpoint
  stepca_fingerprint = var.stepca_fingerprint
  cert_duration      = "24h"
}
```

## Test plan

- [x] `tofu fmt` passes
- [x] `tofu validate` passes
- [ ] CI pipeline passes

Part of #59 (Phase 3: Terraform TLS configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)