### PR TITLE
feat: add Caddy support for internal CA TLS backends (Phase 5)

### DIFF
--- a/terraform/modules/caddy/main.tf
+++ b/terraform/modules/caddy/main.tf
@@ -65,4 +65,14 @@ resource "incus_instance" "caddy" {
     target_path = "/etc/caddy/Caddyfile"
     mode        = "0644"
   }
+
+  # Internal CA certificate for backend TLS connections (optional)
+  dynamic "file" {
+    for_each = var.internal_ca_certificate != "" ? [1] : []
+    content {
+      content     = var.internal_ca_certificate
+      target_path = "/etc/caddy/internal-ca.crt"
+      mode        = "0644"
+    }
+  }
 }

--- a/terraform/modules/caddy/variables.tf
+++ b/terraform/modules/caddy/variables.tf
@@ -76,3 +76,11 @@ variable "service_blocks" {
   type        = list(string)
   default     = []
 }
+
+# Internal TLS Configuration
+variable "internal_ca_certificate" {
+  description = "PEM-encoded internal CA certificate for trusting backend TLS connections"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/terraform/modules/grafana/outputs.tf
+++ b/terraform/modules/grafana/outputs.tf
@@ -25,6 +25,7 @@ output "caddy_config_block" {
     allowed_ip_range = var.allowed_ip_range
     instance_name    = var.instance_name
     port             = var.grafana_port
+    backend_tls      = var.enable_tls
   }) : ""
 }
 

--- a/terraform/modules/grafana/templates/caddyfile.tftpl
+++ b/terraform/modules/grafana/templates/caddyfile.tftpl
@@ -23,5 +23,13 @@ ${domain} {
 		-Server
 	}
 
+%{ if backend_tls ~}
+	reverse_proxy https://${instance_name}.incus:${port} {
+		transport http {
+			tls_trust_pool file /etc/caddy/internal-ca.crt
+		}
+	}
+%{ else ~}
 	reverse_proxy ${instance_name}.incus:${port}
+%{ endif ~}
 }


### PR DESCRIPTION
## Summary

Configure Caddy reverse proxy to trust internal step-ca certificates when connecting to backend services with TLS enabled:

- Add `internal_ca_certificate` variable to Caddy module for CA trust
- Update Grafana caddyfile template to use HTTPS with `tls_trust_pool`
- Pass `backend_tls` flag from `enable_tls` variable to template
- Conditionally inject internal CA cert file to `/etc/caddy/internal-ca.crt`

## Usage Example

```hcl
module "caddy01" {
  source = "./modules/caddy"
  
  # Pass internal CA certificate from step-ca module
  internal_ca_certificate = module.stepca01.root_ca_certificate
  
  service_blocks = [
    module.grafana01.caddy_config_block,  # Will use HTTPS if enable_tls=true
  ]
}
```

When a service has `enable_tls = true`, Caddy will:
1. Connect to the backend over HTTPS
2. Verify the certificate using the internal CA

## Test plan

- [x] `tofu fmt -recursive` passes
- [x] `tofu validate` passes
- [ ] CI workflow passes

Completes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)