### PR TITLE
docs: update documentation for OpenTofu and step-ca service

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,8 +18,9 @@ All production images are published to GitHub Container Registry:
 - **Grafana**: `ghcr.io/accuser/atlas/grafana:latest`
 - **Loki**: `ghcr.io/accuser/atlas/loki:latest`
 - **Prometheus**: `ghcr.io/accuser/atlas/prometheus:latest`
+- **step-ca**: `ghcr.io/accuser/atlas/step-ca:latest`
 
-These images are used by default in all Terraform modules.
+These images are used by default in all OpenTofu modules.
 
 ## Local Development
 
@@ -36,6 +37,7 @@ make build-caddy
 make build-grafana
 make build-loki
 make build-prometheus
+make build-step-ca
 ```
 
 ### Viewing Built Images
@@ -57,7 +59,7 @@ docker images | grep atlas
 When you push code to GitHub:
 
 1. **GitHub Actions triggers** on push to `main` or `develop` branches
-2. **Docker images are built** in parallel (all four services)
+2. **Docker images are built** in parallel (all five services)
 3. **Images are published** to ghcr.io with appropriate tags
 4. **Images are cached** for faster subsequent builds
 
@@ -74,16 +76,16 @@ Published images receive multiple tags:
 After the first push, images default to private. To make them public:
 
 1. Visit: `https://github.com/accuser/atlas/packages`
-2. Click on each package (atlas-caddy, atlas-grafana, atlas-loki, atlas-prometheus)
+2. Click on each package (caddy, grafana, loki, prometheus, step-ca)
 3. Go to "Package settings"
 4. Scroll to "Danger Zone"
 5. Click "Change visibility" → "Public"
 
-## Using Custom Images in Terraform
+## Using Custom Images in OpenTofu
 
 ### Default Configuration
 
-All Terraform modules default to ghcr.io images:
+All OpenTofu modules default to ghcr.io images:
 
 ```hcl
 module "grafana01" {
@@ -344,7 +346,7 @@ If you prefer Docker Hub over ghcr.io:
    images: docker.io/yourusername/${{ matrix.service }}
    ```
 
-3. **Update Terraform modules** to use Docker Hub images
+3. **Update OpenTofu modules** to use Docker Hub images
 
 ## See Also
 
@@ -356,3 +358,4 @@ If you prefer Docker Hub over ghcr.io:
   - [grafana/README.md](grafana/README.md) - Grafana plugins and provisioning
   - [loki/README.md](loki/README.md) - Loki configuration
   - [prometheus/README.md](prometheus/README.md) - Prometheus rules and configuration
+  - [step-ca/README.md](step-ca/README.md) - step-ca internal PKI configuration

--- a/terraform/BACKEND_SETUP.md
+++ b/terraform/BACKEND_SETUP.md
@@ -1,14 +1,14 @@
-# Terraform Remote State Backend Setup
+# OpenTofu Remote State Backend Setup
 
-This guide explains how to configure Terraform to use Incus storage buckets as a remote state backend, providing encrypted and secure state management without external dependencies.
+This guide explains how to configure OpenTofu to use Incus storage buckets as a remote state backend, providing encrypted and secure state management without external dependencies.
 
 ## Overview
 
-Instead of storing Terraform state locally, we use Incus's built-in S3-compatible storage buckets. This provides:
+Instead of storing OpenTofu state locally, we use Incus's built-in S3-compatible storage buckets. This provides:
 
 - **Encryption**: State data encrypted at rest
 - **Self-hosted**: No external cloud dependencies
-- **S3-compatible**: Works with Terraform's S3 backend
+- **S3-compatible**: Works with OpenTofu's S3 backend
 - **Integrated**: Uses existing Incus infrastructure
 - **Secure**: Access controlled via S3 credentials
 
@@ -20,7 +20,7 @@ Choose the method that fits your situation:
 
 **Use this for**: Fresh Incus installations, first-time setup
 
-The bootstrap Terraform project automates all setup steps:
+The bootstrap OpenTofu project automates all setup steps:
 
 ```bash
 # From project root
@@ -28,10 +28,10 @@ make bootstrap
 
 # Or manually:
 cd terraform/bootstrap
-terraform init
-terraform apply
+tofu init
+tofu apply
 cd ..
-terraform init -backend-config=backend.hcl
+tofu init -backend-config=backend.hcl
 ```
 
 See [bootstrap/README.md](bootstrap/README.md) for details.
@@ -55,8 +55,8 @@ The bootstrap process creates everything needed for remote state:
 
 2. **Initialize and apply**:
    ```bash
-   terraform init
-   terraform apply
+   tofu init
+   tofu apply
    ```
 
 3. **Review the output** - Bootstrap creates:
@@ -69,12 +69,12 @@ The bootstrap process creates everything needed for remote state:
 4. **Initialize main project**:
    ```bash
    cd ..
-   terraform init -backend-config=backend.hcl
+   tofu init -backend-config=backend.hcl
    ```
 
 5. **Deploy infrastructure**:
    ```bash
-   terraform apply
+   tofu apply
    ```
 
 **That's it!** The bootstrap handles all the setup automatically.
@@ -90,7 +90,7 @@ For customization options, see [bootstrap/README.md](bootstrap/README.md).
 - Incus installed and running (`incus admin init` completed)
 - Admin access to configure Incus
 - Network connectivity to Incus host
-- Terraform >= 1.6.0 (uses `endpoints.s3` syntax instead of deprecated `endpoint`)
+- OpenTofu >= 1.6.0 (uses `endpoints.s3` syntax instead of deprecated `endpoint`)
 
 ## Manual Setup Instructions
 
@@ -135,7 +135,7 @@ incus storage bucket list terraform-state
 
 ### 4. Generate S3 Credentials
 
-Create access credentials for Terraform to use:
+Create access credentials for OpenTofu to use:
 
 ```bash
 # Create credentials (replace with your own names)
@@ -146,9 +146,9 @@ incus storage bucket key create terraform-state atlas-terraform-state terraform-
 # Secret key: <SECRET_KEY>
 ```
 
-**Important**: Save these credentials securely. You'll need them for Terraform configuration.
+**Important**: Save these credentials securely. You'll need them for OpenTofu configuration.
 
-### 5. Configure Terraform Backend
+### 5. Configure OpenTofu Backend
 
 The backend configuration is already included in `versions.tf`. You need to provide the credentials via environment variables or a backend config file.
 
@@ -161,11 +161,11 @@ export TF_BACKEND_BUCKET="atlas-terraform-state"
 export TF_BACKEND_ENDPOINT="http://localhost:8555"  # Or your Incus host IP
 ```
 
-Then initialize Terraform:
+Then initialize OpenTofu:
 
 ```bash
 cd terraform
-terraform init \
+tofu init \
   -backend-config="access_key=$AWS_ACCESS_KEY_ID" \
   -backend-config="secret_key=$AWS_SECRET_ACCESS_KEY" \
   -backend-config="bucket=$TF_BACKEND_BUCKET" \
@@ -178,7 +178,7 @@ Create a `backend.hcl` file (gitignored):
 
 ```hcl
 # terraform/backend.hcl
-# Terraform 1.6+ requires endpoints block instead of endpoint parameter
+# OpenTofu 1.6+ requires endpoints block instead of endpoint parameter
 bucket     = "atlas-terraform-state"
 access_key = "<ACCESS_KEY>"
 secret_key = "<SECRET_KEY>"
@@ -192,7 +192,7 @@ Then initialize:
 
 ```bash
 cd terraform
-terraform init -backend-config=backend.hcl
+tofu init -backend-config=backend.hcl
 ```
 
 ### 6. Migrate Existing State (if applicable)
@@ -203,13 +203,13 @@ If you have existing local state, migrate it:
 cd terraform
 
 # Initialize with new backend
-terraform init -migrate-state
+tofu init -migrate-state
 
 # Verify migration
-terraform state list
+tofu state list
 ```
 
-Terraform will prompt to copy existing state to the new backend. Answer `yes` to proceed.
+OpenTofu will prompt to copy existing state to the new backend. Answer `yes` to proceed.
 
 ### 7. Verify Remote State
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
-# Terraform Infrastructure
+# OpenTofu Infrastructure
 
-This directory contains the Terraform configuration for the Atlas monitoring stack infrastructure.
+This directory contains the OpenTofu configuration for the Atlas monitoring stack infrastructure.
 
 ## Quick Start
 
@@ -16,7 +16,7 @@ make terraform-apply   # Apply changes
 
 ## Important: Initialization
 
-**Do not run `terraform init` directly** - it will fail because the S3 backend requires configuration that must be provided via `-backend-config`.
+**Do not run `tofu init` directly** - it will fail because the S3 backend requires configuration that must be provided via `-backend-config`.
 
 ### Correct Ways to Initialize
 
@@ -34,7 +34,7 @@ make terraform-apply   # Apply changes
 3. **Manual initialization with backend config**:
    ```bash
    cd terraform
-   terraform init -backend-config=backend.hcl
+   tofu init -backend-config=backend.hcl
    ```
 
 ### Why This Is Required
@@ -46,7 +46,7 @@ If you see this error:
 Error: Error asking for input to configure backend "s3": bucket: EOF
 ```
 
-It means you're running `terraform init` without the required backend configuration.
+It means you're running `tofu init` without the required backend configuration.
 
 ## First-Time Setup
 
@@ -57,7 +57,7 @@ For a fresh installation:
    make bootstrap
    ```
 
-2. **Initialize Terraform**:
+2. **Initialize OpenTofu**:
    ```bash
    make terraform-init
    ```
@@ -85,11 +85,12 @@ terraform/
 ├── terraform.tfvars     # Variable values (gitignored)
 ├── BACKEND_SETUP.md     # Backend setup guide
 ├── bootstrap/           # Bootstrap project (local state)
-└── modules/             # Reusable Terraform modules
+└── modules/             # Reusable OpenTofu modules
     ├── caddy/
     ├── grafana/
     ├── loki/
-    └── prometheus/
+    ├── prometheus/
+    └── step-ca/
 ```
 
 ## Common Commands
@@ -102,12 +103,12 @@ make terraform-apply     # Apply changes
 make terraform-destroy   # Destroy infrastructure
 make format              # Format Terraform files
 
-# Direct Terraform commands (after initialization)
+# Direct OpenTofu commands (after initialization)
 cd terraform
-terraform plan
-terraform apply
-terraform output
-terraform state list
+tofu plan
+tofu apply
+tofu output
+tofu state list
 ```
 
 ## Configuration Files
@@ -122,13 +123,13 @@ cloudflare_api_token = "your-token"
 
 ### backend.hcl (gitignored)
 
-Contains S3 backend credentials (Terraform 1.6+ syntax):
+Contains S3 backend credentials (OpenTofu 1.6+ syntax):
 ```hcl
 bucket     = "atlas-terraform-state"
 access_key = "your-access-key"
 secret_key = "your-secret-key"
 
-# Terraform 1.6+ requires endpoints block
+# OpenTofu 1.6+ requires endpoints block
 endpoints = {
   s3 = "http://localhost:8555"
 }
@@ -138,7 +139,7 @@ endpoints = {
 
 ### "Error asking for input to configure backend"
 
-Run `make terraform-init` or `./init.sh` instead of `terraform init`.
+Run `make terraform-init` or `./init.sh` instead of `tofu init`.
 
 ### "backend.hcl not found"
 


### PR DESCRIPTION
## Summary

Updates documentation across the project to reflect:
- Migration from Terraform to OpenTofu (command references)
- Addition of step-ca service for internal PKI
- Correct network count (5 networks, not 3)

## Changes

### README.md
- Changed "Terraform-based" to "OpenTofu-based" in project description
- Added step-ca to services list and project structure
- Updated network count from 3 to 5 with correct CIDR ranges
- Added step-ca to Docker image registry list
- Updated command examples to use `tofu` instead of `terraform`

### docker/README.md
- Added step-ca to image registry list
- Changed "all Terraform modules" to "all OpenTofu modules"
- Added `make build-step-ca` to build commands
- Changed "all four services" to "all five services"

### terraform/README.md
- Changed title to "OpenTofu Infrastructure"
- Updated init commands to use `tofu`
- Added step-ca to modules directory listing

### terraform/BACKEND_SETUP.md
- Changed all Terraform references to OpenTofu throughout
- Updated version requirement to "OpenTofu >= 1.6.0"

## Test plan

- [x] Documentation changes are accurate and consistent
- [x] All `terraform` command references updated to `tofu`
- [x] step-ca service included in all relevant sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)