### PR TITLE
feat: add step-ca instance for internal TLS support

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -132,3 +132,41 @@ module "prometheus01" {
     incus_network.management
   ]
 }
+
+module "step_ca01" {
+  source = "./modules/step-ca"
+
+  instance_name = "step-ca01"
+  profile_name  = "step-ca"
+
+  # Network configuration - use management network for internal services
+  network_name = incus_network.management.name
+
+  # CA configuration
+  ca_name      = "Atlas Internal CA"
+  ca_dns_names = "step-ca01.incus,step-ca01,localhost"
+
+  # ACME endpoint configuration
+  acme_port = "9000"
+
+  # Certificate settings
+  cert_duration = "24h"
+
+  # Enable persistent storage for CA data
+  enable_data_persistence = true
+  data_volume_name        = "step-ca01-data"
+  data_volume_size        = "1GB"
+
+  # Resource limits - step-ca is lightweight
+  cpu_limit    = "1"
+  memory_limit = "512MB"
+
+  # Ensure networks are created before the container
+  depends_on = [
+    incus_network.development,
+    incus_network.testing,
+    incus_network.staging,
+    incus_network.production,
+    incus_network.management
+  ]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,3 +12,13 @@ output "prometheus_endpoint" {
   description = "Prometheus endpoint URL for internal use (configure as Grafana data source)"
   value       = module.prometheus01.prometheus_endpoint
 }
+
+output "step_ca_acme_endpoint" {
+  description = "step-ca ACME endpoint URL for certificate requests"
+  value       = module.step_ca01.acme_endpoint
+}
+
+output "step_ca_acme_directory" {
+  description = "step-ca ACME directory URL for ACME clients"
+  value       = module.step_ca01.acme_directory
+}


### PR DESCRIPTION
## Summary

- Add `step_ca01` module instantiation to deploy internal PKI/ACME CA
- Configure step-ca on management network with persistent storage
- Add ACME endpoint outputs for use by other services

## Configuration

| Setting | Value |
|---------|-------|
| Instance | `step-ca01` |
| Network | management |
| CA Name | Atlas Internal CA |
| ACME Port | 9000 |
| Storage | 1GB persistent |
| Resources | 1 CPU, 512MB memory |

## Test plan

- [ ] `tofu validate` passes
- [ ] `tofu plan` shows expected resources
- [ ] step-ca container starts successfully
- [ ] ACME endpoint is accessible from management network

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)