### PR TITLE
docs: update documentation for step-ca and bootstrap improvements

### DIFF
--- a/terraform/bootstrap/README.md
+++ b/terraform/bootstrap/README.md
@@ -231,9 +231,17 @@ terraform apply \
 Bootstrap is safe to re-run:
 - Checks if resources exist before creating
 - Skips already-configured settings
-- Won't overwrite existing credentials
+- Won't overwrite existing credentials unless role upgrade is needed
+- Automatically upgrades existing credentials from read-only to admin role
 
-To regenerate credentials:
+### Credential Role Management
+
+Bootstrap creates credentials with the `admin` role, which is required for Terraform state operations (read and write). If existing credentials have a read-only role, bootstrap will automatically:
+1. Delete the existing credentials
+2. Recreate them with the `admin` role
+3. Update the `backend.hcl` file with the new credentials
+
+To manually regenerate credentials:
 ```bash
 incus storage bucket key delete terraform-state atlas-terraform-state terraform-access
 terraform apply


### PR DESCRIPTION
## Summary
- Add step-ca service to project structure and infrastructure documentation in CLAUDE.md
- Document step-ca module, instance, storage volumes, Docker images, and outputs
- Update bootstrap README idempotency section to document admin role credential management

## Changes
- **CLAUDE.md**: Added step-ca throughout (project structure, Docker images, infrastructure components 11 & 12, storage volumes, outputs)
- **terraform/bootstrap/README.md**: Enhanced idempotency section with credential role management documentation

## Test plan
- [ ] Review documentation updates for accuracy
- [ ] Verify all step-ca references are consistent with terraform/main.tf

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)