### PR TITLE
feat: add explicit warnings to Makefile apply and destroy targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,33 @@ plan:
 	cd terraform && tofu plan
 
 apply:
-	@echo "Applying OpenTofu changes..."
+	@echo "=========================================="
+	@echo "WARNING: Applying infrastructure changes"
+	@echo "=========================================="
+	@echo ""
+	@echo "This will modify your infrastructure based on the current configuration."
+	@echo ""
+	@echo "Recommended: Review the plan first with 'make plan'"
+	@echo ""
+	@echo "OpenTofu will prompt for confirmation before applying."
+	@echo ""
 	cd terraform && tofu apply
 
 destroy:
-	@echo "Destroying infrastructure..."
+	@echo "=========================================="
+	@echo "⚠️  WARNING: DESTRUCTIVE OPERATION"
+	@echo "=========================================="
+	@echo ""
+	@echo "This will DESTROY all infrastructure managed by OpenTofu:"
+	@echo "  - All containers (caddy01, grafana01, loki01, prometheus01, step-ca01)"
+	@echo "  - All storage volumes (data will be DELETED)"
+	@echo "  - All profiles"
+	@echo "  - All networks"
+	@echo ""
+	@echo "This action is IRREVERSIBLE!"
+	@echo ""
+	@echo "OpenTofu will prompt for confirmation before destroying."
+	@echo ""
 	cd terraform && tofu destroy
 
 # Import existing resources into state


### PR DESCRIPTION
## Summary
- Add clear warning banners to `make apply` and `make destroy` targets
- Improve safety by providing context before OpenTofu's confirmation prompt
- List all resources that will be affected by destroy operation

## Changes

### Makefile - `apply` target
Added warning banner that:
- Notifies user about infrastructure changes
- Recommends running `make plan` first for review
- Clarifies that OpenTofu will still prompt for confirmation

### Makefile - `destroy` target
Added prominent destructive operation warning that:
- Uses ⚠️ emoji for visual emphasis
- Lists all resources that will be destroyed:
  - All containers (caddy01, grafana01, loki01, prometheus01, step-ca01)
  - All storage volumes (with data deletion warning)
  - All profiles
  - All networks
- Emphasizes the operation is IRREVERSIBLE
- Clarifies that OpenTofu will still prompt for confirmation

## Example Output

**`make apply`:**
```
==========================================
WARNING: Applying infrastructure changes
==========================================

This will modify your infrastructure based on the current configuration.

Recommended: Review the plan first with 'make plan'

OpenTofu will prompt for confirmation before applying.

[OpenTofu output follows...]
```

**`make destroy`:**
```
==========================================
⚠️  WARNING: DESTRUCTIVE OPERATION
==========================================

This will DESTROY all infrastructure managed by OpenTofu:
  - All containers (caddy01, grafana01, loki01, prometheus01, step-ca01)
  - All storage volumes (data will be DELETED)
  - All profiles
  - All networks

This action is IRREVERSIBLE!

OpenTofu will prompt for confirmation before destroying.

[OpenTofu output follows...]
```

## Benefits
1. **Improved safety** - Users see clear warnings before destructive operations
2. **Better UX** - Clear context about what will happen
3. **No workflow changes** - OpenTofu still prompts for final confirmation
4. **Educational** - Reminds users about `make plan` for reviewing changes

## Test Plan
- [x] Verify Makefile syntax is correct (`make help` works)
- [ ] Test `make apply` shows warning banner
- [ ] Test `make destroy` shows destructive operation warning
- [ ] Verify OpenTofu still prompts for confirmation after warnings

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)