### PR TITLE
feat: add rate limiting to Caddy reverse proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,7 @@ The project uses Terraform modules for scalability and reusability:
    - Reverse proxy with automatic HTTPS via Let's Encrypt
    - Dynamic Caddyfile generation from service module outputs
    - Cloudflare DNS-01 ACME challenge support
+   - Rate limiting protection (mholt/caddy-ratelimit plugin)
    - Triple network interfaces (production + management + external)
    - Accepts `service_blocks` list for dynamic configuration
    - Custom Docker image: [docker/caddy/](docker/caddy/)
@@ -362,6 +363,7 @@ The project uses Terraform modules for scalability and reusability:
    - Environment variable support for configuration
    - Generates Caddy reverse proxy configuration block
    - Domain-based access with IP restrictions
+   - Rate limiting support (configurable requests/window)
    - Custom Docker image: [docker/grafana/](docker/grafana/)
 
 6. **Grafana Instance** (instantiated in [terraform/main.tf](terraform/main.tf))
@@ -726,6 +728,14 @@ module "caddy01" {
 - Public services exposed via Caddy reverse proxy with triple NICs (production, management, external)
 - IP-based access control for security
 - Automatic HTTPS via Let's Encrypt with Cloudflare DNS validation
+
+**Rate Limiting:**
+- Built-in rate limiting via mholt/caddy-ratelimit plugin
+- Default limits: 100 requests/min for general endpoints, 10 requests/min for login endpoints
+- Sliding window algorithm for smooth rate limiting
+- Per-service zones prevent cross-service interference
+- Configurable via Terraform variables (`enable_rate_limiting`, `rate_limit_requests`, etc.)
+- Protects against brute force attacks, DoS attempts, and resource exhaustion
 
 **Storage Management:**
 - Each service module manages its own storage volume

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,20 +1,26 @@
-# Custom Caddy with Cloudflare DNS plugin
-# Pinned to v2.10.2 for reproducibility and security
-FROM caddybuilds/caddy-cloudflare:2.10.2
+# Custom Caddy with Cloudflare DNS and rate limiting plugins
+# Built using xcaddy for reproducibility and security
 
-# Add any custom Caddy modules or configuration here
-# Example: COPY custom-plugins /usr/local/bin/
+# Build stage: compile Caddy with plugins
+FROM caddy:2.10.2-builder-alpine AS builder
 
-# The Caddyfile will be managed by Terraform and injected at runtime
-# No need to copy it here unless you want a default fallback
+RUN xcaddy build \
+    --with github.com/caddy-dns/cloudflare \
+    --with github.com/mholt/caddy-ratelimit
+
+# Runtime stage
+FROM caddy:2.10.2-alpine
+
+# Copy custom Caddy binary with plugins
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
 # OCI metadata labels for container management
 LABEL maintainer="hello@accuser.dev"
-LABEL description="Custom Caddy reverse proxy with Cloudflare DNS support"
+LABEL description="Custom Caddy reverse proxy with Cloudflare DNS and rate limiting"
 LABEL org.opencontainers.image.source="https://github.com/accuser/atlas"
 LABEL org.opencontainers.image.version="2.10.2"
 LABEL org.opencontainers.image.title="Atlas Caddy"
-LABEL org.opencontainers.image.description="Caddy reverse proxy with Cloudflare DNS for automatic HTTPS"
+LABEL org.opencontainers.image.description="Caddy reverse proxy with Cloudflare DNS for automatic HTTPS and rate limiting protection"
 LABEL org.opencontainers.image.vendor="accuser"
 
 # Set working directory
@@ -25,6 +31,5 @@ WORKDIR /srv
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD caddy version || exit 1
 
-# Note: The caddybuilds/caddy-cloudflare image doesn't include a non-root user
-# The container runs as root but Caddy itself drops privileges appropriately
-# For production with Incus, the container runs with restricted capabilities
+# Note: The caddy:alpine image runs as non-root by default
+# Caddy itself handles privilege dropping appropriately

--- a/docker/caddy/README.md
+++ b/docker/caddy/README.md
@@ -1,12 +1,17 @@
 # Caddy Custom Image
 
-This directory contains the Dockerfile for building a custom Caddy image based on `caddybuilds/caddy-cloudflare`.
+This directory contains the Dockerfile for building a custom Caddy image with Cloudflare DNS and rate limiting plugins using xcaddy.
 
-## Base Image
+## Build Process
 
-- **Base**: `caddybuilds/caddy-cloudflare:2.10.2`
-- **Includes**: Caddy web server with Cloudflare DNS plugin for ACME DNS-01 challenges
-- **Version**: Pinned to 2.10.2 for reproducibility and security (Dependabot tracks updates)
+The image uses a multi-stage build:
+1. **Builder stage**: Uses `caddy:2.10.2-builder-alpine` with xcaddy to compile Caddy with plugins
+2. **Runtime stage**: Uses `caddy:2.10.2-alpine` for a minimal runtime environment
+
+## Included Plugins
+
+- **[caddy-dns/cloudflare](https://github.com/caddy-dns/cloudflare)**: Cloudflare DNS provider for ACME DNS-01 challenges
+- **[mholt/caddy-ratelimit](https://github.com/mholt/caddy-ratelimit)**: Rate limiting with sliding window algorithm
 
 ## Building
 
@@ -20,11 +25,39 @@ make build-caddy
 
 ## Image Features
 
+### Cloudflare DNS Support
+
+Enables automatic HTTPS certificate provisioning using Cloudflare DNS-01 challenges:
+- Works with wildcard certificates
+- No need to expose ports 80/443 during certificate issuance
+- Supports Cloudflare API tokens for secure authentication
+
+### Rate Limiting
+
+Protects against brute force attacks, DoS attempts, and resource exhaustion:
+
+**Default Configuration (per service):**
+- General endpoints: 100 requests per minute per IP
+- Login endpoints: 10 requests per minute per IP (stricter)
+
+**Configurable via Terraform variables:**
+```hcl
+module "grafana01" {
+  # ... other config
+
+  # Rate limiting configuration
+  enable_rate_limiting      = true   # Enable/disable rate limiting
+  rate_limit_requests       = 100    # Requests per window
+  rate_limit_window         = "1m"   # Time window (1m, 30s, 1h)
+  login_rate_limit_requests = 10     # Stricter limit for login endpoints
+  login_rate_limit_window   = "1m"   # Login endpoint time window
+}
+```
+
 ### Security Enhancements
 
 **Container User**
-- The `caddybuilds/caddy-cloudflare` base image runs as root
-- Caddy internally manages privileges appropriately
+- Base image runs Caddy with appropriate privileges
 - When deployed via Incus, the container runs with restricted capabilities
 - Production deployments benefit from Incus container isolation
 
@@ -50,18 +83,20 @@ make build-caddy
 
 ## Customization
 
-To add custom Caddy plugins or configuration:
+To add additional Caddy plugins:
 
-1. Add plugin build instructions to the Dockerfile
-2. Copy any static configuration files needed
+1. Edit the Dockerfile's xcaddy build command
+2. Add the plugin with `--with github.com/example/caddy-plugin`
 3. Rebuild the image
 
-### Example: Adding a Custom Plugin
+### Example: Adding Another Plugin
 
 ```dockerfile
-# After the FROM line, add:
+# In the builder stage, modify the xcaddy build:
 RUN xcaddy build \
-    --with github.com/example/caddy-plugin
+    --with github.com/caddy-dns/cloudflare \
+    --with github.com/mholt/caddy-ratelimit \
+    --with github.com/example/another-plugin
 ```
 
 ## Usage in Terraform
@@ -86,3 +121,19 @@ make build-caddy
 cd terraform
 tofu plan
 ```
+
+## Rate Limiting Details
+
+The rate limiting plugin uses a sliding window algorithm with the following behavior:
+- Requests are tracked per client IP address
+- When the limit is exceeded, clients receive a `429 Too Many Requests` response
+- The window slides continuously, providing smooth rate limiting
+- Each service has its own rate limit zones to prevent cross-service interference
+
+### Zone Naming
+
+Rate limit zones are automatically named based on the domain:
+- General zone: `grafana_accuser_dev` (domain with dots replaced by underscores)
+- Login zone: `grafana_accuser_dev_login`
+
+This ensures each service has isolated rate limiting.

--- a/terraform/modules/caddy/templates/Caddyfile.tftpl
+++ b/terraform/modules/caddy/templates/Caddyfile.tftpl
@@ -1,4 +1,7 @@
 {
+	# Order rate_limit directive before basic_auth in the handler chain
+	order rate_limit before basic_auth
+
 	acme_dns cloudflare {file./etc/caddy/cloudflare_token} {
 		resolvers 1.1.1.1
 	}

--- a/terraform/modules/grafana/outputs.tf
+++ b/terraform/modules/grafana/outputs.tf
@@ -21,11 +21,16 @@ output "storage_volume_name" {
 output "caddy_config_block" {
   description = "Caddyfile configuration block for this Grafana instance"
   value = var.domain != "" ? templatefile("${path.module}/templates/caddyfile.tftpl", {
-    domain           = var.domain
-    allowed_ip_range = var.allowed_ip_range
-    instance_name    = var.instance_name
-    port             = var.grafana_port
-    backend_tls      = var.enable_tls
+    domain                    = var.domain
+    allowed_ip_range          = var.allowed_ip_range
+    instance_name             = var.instance_name
+    port                      = var.grafana_port
+    backend_tls               = var.enable_tls
+    enable_rate_limiting      = var.enable_rate_limiting
+    rate_limit_requests       = var.rate_limit_requests
+    rate_limit_window         = var.rate_limit_window
+    login_rate_limit_requests = var.login_rate_limit_requests
+    login_rate_limit_window   = var.login_rate_limit_window
   }) : ""
 }
 

--- a/terraform/modules/grafana/templates/caddyfile.tftpl
+++ b/terraform/modules/grafana/templates/caddyfile.tftpl
@@ -2,6 +2,27 @@ ${domain} {
 	@denied not remote_ip ${allowed_ip_range}
 	abort @denied
 
+%{ if enable_rate_limiting ~}
+	# Rate limiting - ${rate_limit_requests} requests per ${rate_limit_window} per IP
+	rate_limit {
+		zone ${replace(domain, ".", "_")} {
+			key {remote_host}
+			events ${rate_limit_requests}
+			window ${rate_limit_window}
+		}
+	}
+
+	# Stricter rate limits for login endpoints
+	@login path /login* /api/login*
+	rate_limit @login {
+		zone ${replace(domain, ".", "_")}_login {
+			key {remote_host}
+			events ${login_rate_limit_requests}
+			window ${login_rate_limit_window}
+		}
+	}
+
+%{ endif ~}
 	# Security headers
 	header {
 		# HSTS - force HTTPS for 1 year, include subdomains

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -148,3 +148,54 @@ variable "datasources" {
   }))
   default = []
 }
+
+# Rate Limiting
+variable "enable_rate_limiting" {
+  description = "Enable rate limiting for this service"
+  type        = bool
+  default     = true
+}
+
+variable "rate_limit_requests" {
+  description = "Maximum requests allowed per window for normal endpoints"
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.rate_limit_requests >= 1 && var.rate_limit_requests <= 10000
+    error_message = "Rate limit must be between 1 and 10000 requests"
+  }
+}
+
+variable "rate_limit_window" {
+  description = "Time window for rate limiting (e.g., 1m, 5m, 1h)"
+  type        = string
+  default     = "1m"
+
+  validation {
+    condition     = can(regex("^[0-9]+(s|m|h)$", var.rate_limit_window))
+    error_message = "Rate limit window must be in format like '1m', '30s', or '1h'"
+  }
+}
+
+variable "login_rate_limit_requests" {
+  description = "Maximum requests allowed per window for login endpoints (stricter)"
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.login_rate_limit_requests >= 1 && var.login_rate_limit_requests <= 1000
+    error_message = "Login rate limit must be between 1 and 1000 requests"
+  }
+}
+
+variable "login_rate_limit_window" {
+  description = "Time window for login endpoint rate limiting"
+  type        = string
+  default     = "1m"
+
+  validation {
+    condition     = can(regex("^[0-9]+(s|m|h)$", var.login_rate_limit_window))
+    error_message = "Login rate limit window must be in format like '1m', '30s', or '1h'"
+  }
+}


### PR DESCRIPTION
## Summary

- Add rate limiting protection to Caddy using mholt/caddy-ratelimit plugin
- Switch Caddy Dockerfile to multi-stage xcaddy build for custom plugin support
- Configure default limits: 100 req/min for general endpoints, 10 req/min for login endpoints
- Make rate limiting fully configurable via Terraform variables

## Motivation

Protect public-facing services against brute force attacks, DoS attempts, and resource exhaustion by implementing rate limiting at the reverse proxy level.

## Related Issues

Fixes #19

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/configuration change

## Testing

### Testing Steps

1. Build Caddy image locally: `make build-caddy`
2. Verify plugins are included: `docker run --rm atlas/caddy:latest caddy list-modules | grep -E "rate|cloudflare"`
3. Run `tofu validate` to verify Terraform configuration
4. Deploy and test rate limiting with curl requests

### Test Results

```
$ docker run --rm atlas/caddy:latest caddy list-modules | grep -E "rate|cloudflare"
dns.providers.cloudflare
http.handlers.rate_limit

$ tofu validate
Success! The configuration is valid.
```

## Changes Made

- `docker/caddy/Dockerfile` - Multi-stage xcaddy build with cloudflare and ratelimit plugins
- `docker/caddy/README.md` - Updated documentation for new build process and rate limiting
- `terraform/modules/grafana/variables.tf` - Added rate limiting variables with validation
- `terraform/modules/grafana/outputs.tf` - Pass rate limiting vars to Caddyfile template
- `terraform/modules/grafana/templates/caddyfile.tftpl` - Rate limit directives for general and login endpoints
- `terraform/modules/caddy/templates/Caddyfile.tftpl` - Global order directive for rate_limit
- `CLAUDE.md` - Architecture documentation updates

## Breaking Changes

- [x] No breaking changes

Rate limiting is enabled by default but can be disabled with `enable_rate_limiting = false`.

## Security Considerations

- [x] Security improvement - adds protection against brute force and DoS attacks

## Documentation

- [x] CLAUDE.md updated
- [x] Module documentation updated (docker/caddy/README.md)
- [ ] No additional documentation changes needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `tofu fmt` on all Terraform files
- [x] I have run `tofu validate` successfully
- [x] I have run `tofu plan` locally to verify changes (required for Terraform changes)
- [ ] I have added tests that prove my fix is effective or feature works (if applicable)
- [x] New and existing tests pass locally
- [x] No secrets or sensitive data are committed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Branch is up to date with `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)