### PR TITLE
feat: complete TLS integration with step-ca

### DIFF
--- a/docker/step-ca/entrypoint.sh
+++ b/docker/step-ca/entrypoint.sh
@@ -64,13 +64,23 @@ initialize_ca() {
     echo "Root CA certificate: ${STEPPATH}/certs/root_ca.crt"
 }
 
-# Export root CA certificate to a well-known location for easy access
+# Export root CA certificate and fingerprint to well-known locations for easy access
 export_root_ca() {
     if [ -f "${STEPPATH}/certs/root_ca.crt" ]; then
         # Make root CA available at a predictable path
         cp "${STEPPATH}/certs/root_ca.crt" "${STEPPATH}/root-ca.pem"
         chmod 644 "${STEPPATH}/root-ca.pem"
         echo "Root CA exported to ${STEPPATH}/root-ca.pem"
+
+        # Export fingerprint for service bootstrapping
+        FINGERPRINT=$(step certificate fingerprint "${STEPPATH}/certs/root_ca.crt")
+        echo "${FINGERPRINT}" > "${STEPPATH}/fingerprint"
+        chmod 644 "${STEPPATH}/fingerprint"
+        echo "======================================================"
+        echo "CA FINGERPRINT: ${FINGERPRINT}"
+        echo "======================================================"
+        echo "Use this fingerprint to configure TLS for services."
+        echo "Fingerprint also saved to: ${STEPPATH}/fingerprint"
     fi
 }
 

--- a/terraform/modules/step-ca/outputs.tf
+++ b/terraform/modules/step-ca/outputs.tf
@@ -22,3 +22,13 @@ output "ca_name" {
   description = "Name of the Certificate Authority"
   value       = var.ca_name
 }
+
+output "fingerprint_command" {
+  description = "Command to retrieve the CA fingerprint after deployment"
+  value       = "incus exec ${var.instance_name} -- cat /home/step/fingerprint"
+}
+
+output "fingerprint_file_path" {
+  description = "Path to the fingerprint file inside the container"
+  value       = "/home/step/fingerprint"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -23,6 +23,11 @@ output "step_ca_acme_directory" {
   value       = module.step_ca01.acme_directory
 }
 
+output "step_ca_fingerprint_command" {
+  description = "Command to retrieve the CA fingerprint (run after deployment)"
+  value       = module.step_ca01.fingerprint_command
+}
+
 output "node_exporter_endpoint" {
   description = "Node Exporter metrics endpoint URL for host monitoring"
   value       = module.node_exporter01.node_exporter_endpoint


### PR DESCRIPTION
## Summary
- Add fingerprint export to step-ca entrypoint (outputs to `/home/step/fingerprint`)
- Add `fingerprint_command` and `fingerprint_file_path` outputs to step-ca module
- Add `step_ca_fingerprint_command` output to root outputs
- Add comprehensive TLS Configuration section to CLAUDE.md
- Update step-ca instance description (now uses `:latest` tag)
- Document two-phase deployment workflow for TLS enablement
- Add troubleshooting commands for TLS issues

## Why Two-Phase Deployment?
The CA fingerprint is generated at runtime when step-ca initializes its root CA certificate. This means:
1. First deploy creates step-ca and generates the fingerprint
2. Retrieve fingerprint via `incus exec step-ca01 -- cat /home/step/fingerprint`
3. Second deploy enables TLS on services with the fingerprint

## Test plan
- [ ] Verify `tofu validate` passes
- [ ] Deploy step-ca and verify fingerprint is exported to `/home/step/fingerprint`
- [ ] Verify `tofu output step_ca_fingerprint_command` shows correct command
- [ ] Test enabling TLS on Grafana with the fingerprint
- [ ] Verify CLAUDE.md TLS documentation is accurate

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)