### PR TITLE
refactor: derive Grafana datasources from module outputs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,21 +52,21 @@ module "grafana01" {
     GF_SERVER_HTTP_PORT        = "3000"
   }
 
-  # Configure datasources for Prometheus and Loki
+  # Configure datasources for Prometheus and Loki (derived from module outputs)
   datasources = [
     {
       name            = "Prometheus"
       type            = "prometheus"
-      url             = "http://prometheus01.incus:9090"
+      url             = module.prometheus01.prometheus_endpoint
       is_default      = true
-      tls_skip_verify = false
+      tls_skip_verify = module.prometheus01.tls_enabled # Skip verify for internal CA
     },
     {
       name            = "Loki"
       type            = "loki"
-      url             = "http://loki01.incus:3100"
+      url             = module.loki01.loki_endpoint
       is_default      = false
-      tls_skip_verify = false
+      tls_skip_verify = module.loki01.tls_enabled # Skip verify for internal CA
     }
   ]
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Prometheus URL with `module.prometheus01.prometheus_endpoint`
- Replace hardcoded Loki URL with `module.loki01.loki_endpoint`
- Use `tls_enabled` output to set `tls_skip_verify` dynamically

## Pattern Established
This establishes a clean pattern for adding datasources to Grafana:

```hcl
datasources = [
  {
    name            = "ServiceName"
    type            = "service-type"
    url             = module.service01.service_endpoint  # From module output
    is_default      = false
    tls_skip_verify = module.service01.tls_enabled       # Auto-configured
  }
]
```

When TLS is enabled on a service, `tls_skip_verify` is automatically set to `true` for the internal CA certificates.

## Test plan
- [ ] Verify `tofu validate` passes
- [ ] Verify `tofu plan` shows no changes (URLs should resolve to same values)
- [ ] Deploy and verify Grafana datasources are configured correctly

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)