### PR TITLE
feat: add optional IPv6 support for networks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,8 @@ The project uses Terraform modules for scalability and reusability:
 2. **Network Configuration** ([terraform/networks.tf](terraform/networks.tf))
    - Five managed networks: development, testing, staging, production, management
    - Each network has configurable IPv4 addresses (default 10.10.0.1/24 through 10.50.0.1/24)
-   - NAT enabled for external connectivity
+   - Optional IPv6 support (dual-stack) using ULA addresses (e.g., fd00:10:10::1/64)
+   - NAT enabled for external connectivity (configurable for both IPv4 and IPv6)
    - Management network (10.50.0.1/24) hosts internal services like monitoring
 
 3. **Caddy Module** ([terraform/modules/caddy/](terraform/modules/caddy/))
@@ -869,12 +870,20 @@ module "caddy01" {
 
 **Network Architecture:**
 - Five managed networks: development (10.10.0.1/24), testing (10.20.0.1/24), staging (10.30.0.1/24), production (10.40.0.1/24), management (10.50.0.1/24)
+- Optional IPv6 dual-stack support using ULA addresses (fd00:10:XX::1/64)
 - Application environments: development, testing, staging, production
 - Management network: hosts internal services (monitoring stack: Grafana, Loki, Prometheus)
 - Services on same network can communicate via internal DNS
 - Public services exposed via Caddy reverse proxy with triple NICs (production, management, external)
 - IP-based access control for security
 - Automatic HTTPS via Let's Encrypt with Cloudflare DNS validation
+
+**IPv6 Configuration:**
+- IPv6 is disabled by default (set to empty string)
+- Enable by setting `*_network_ipv6` variables in terraform.tfvars
+- Uses ULA (Unique Local Address) prefix fd00::/8 for private addressing
+- NAT66 configurable per-network via `*_network_ipv6_nat` variables
+- Example: `production_network_ipv6 = "fd00:10:40::1/64"`
 
 **Rate Limiting:**
 - Built-in rate limiting via mholt/caddy-ratelimit plugin

--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -3,10 +3,18 @@ resource "incus_network" "development" {
   description = "Development network"
   type        = "bridge"
 
-  config = {
-    "ipv4.address" = var.development_network_ipv4
-    "ipv4.nat"     = tostring(var.development_network_nat)
-  }
+  config = merge(
+    {
+      "ipv4.address" = var.development_network_ipv4
+      "ipv4.nat"     = tostring(var.development_network_nat)
+    },
+    var.development_network_ipv6 != "" ? {
+      "ipv6.address" = var.development_network_ipv6
+      "ipv6.nat"     = tostring(var.development_network_ipv6_nat)
+      } : {
+      "ipv6.address" = "none"
+    }
+  )
 }
 
 resource "incus_network" "testing" {
@@ -14,10 +22,18 @@ resource "incus_network" "testing" {
   description = "Testing network"
   type        = "bridge"
 
-  config = {
-    "ipv4.address" = var.testing_network_ipv4
-    "ipv4.nat"     = tostring(var.testing_network_nat)
-  }
+  config = merge(
+    {
+      "ipv4.address" = var.testing_network_ipv4
+      "ipv4.nat"     = tostring(var.testing_network_nat)
+    },
+    var.testing_network_ipv6 != "" ? {
+      "ipv6.address" = var.testing_network_ipv6
+      "ipv6.nat"     = tostring(var.testing_network_ipv6_nat)
+      } : {
+      "ipv6.address" = "none"
+    }
+  )
 }
 
 resource "incus_network" "staging" {
@@ -25,10 +41,18 @@ resource "incus_network" "staging" {
   description = "Staging network"
   type        = "bridge"
 
-  config = {
-    "ipv4.address" = var.staging_network_ipv4
-    "ipv4.nat"     = tostring(var.staging_network_nat)
-  }
+  config = merge(
+    {
+      "ipv4.address" = var.staging_network_ipv4
+      "ipv4.nat"     = tostring(var.staging_network_nat)
+    },
+    var.staging_network_ipv6 != "" ? {
+      "ipv6.address" = var.staging_network_ipv6
+      "ipv6.nat"     = tostring(var.staging_network_ipv6_nat)
+      } : {
+      "ipv6.address" = "none"
+    }
+  )
 }
 
 resource "incus_network" "production" {
@@ -36,10 +60,18 @@ resource "incus_network" "production" {
   description = "Production network"
   type        = "bridge"
 
-  config = {
-    "ipv4.address" = var.production_network_ipv4
-    "ipv4.nat"     = tostring(var.production_network_nat)
-  }
+  config = merge(
+    {
+      "ipv4.address" = var.production_network_ipv4
+      "ipv4.nat"     = tostring(var.production_network_nat)
+    },
+    var.production_network_ipv6 != "" ? {
+      "ipv6.address" = var.production_network_ipv6
+      "ipv6.nat"     = tostring(var.production_network_ipv6_nat)
+      } : {
+      "ipv6.address" = "none"
+    }
+  )
 }
 
 resource "incus_network" "management" {
@@ -47,8 +79,16 @@ resource "incus_network" "management" {
   description = "Management network for internal services (monitoring, etc.)"
   type        = "bridge"
 
-  config = {
-    "ipv4.address" = var.management_network_ipv4
-    "ipv4.nat"     = tostring(var.management_network_nat)
-  }
+  config = merge(
+    {
+      "ipv4.address" = var.management_network_ipv4
+      "ipv4.nat"     = tostring(var.management_network_nat)
+    },
+    var.management_network_ipv6 != "" ? {
+      "ipv6.address" = var.management_network_ipv6
+      "ipv6.nat"     = tostring(var.management_network_ipv6_nat)
+      } : {
+      "ipv6.address" = "none"
+    }
+  )
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -22,26 +22,36 @@ grafana_admin_password = "your-secure-grafana-password-here"
 # Override these if you need different network ranges
 # Default values are shown below - uncomment to customize
 
-# Development Network (default: 10.10.0.1/24)
-# development_network_ipv4 = "10.10.0.1/24"
-# development_network_nat  = true
+# Development Network (default: 10.10.0.1/24, IPv6 disabled)
+# development_network_ipv4     = "10.10.0.1/24"
+# development_network_nat      = true
+# development_network_ipv6     = "fd00:10:10::1/64"  # Uncomment to enable IPv6
+# development_network_ipv6_nat = true
 
-# Testing Network (default: 10.20.0.1/24)
-# testing_network_ipv4 = "10.20.0.1/24"
-# testing_network_nat  = true
+# Testing Network (default: 10.20.0.1/24, IPv6 disabled)
+# testing_network_ipv4     = "10.20.0.1/24"
+# testing_network_nat      = true
+# testing_network_ipv6     = "fd00:10:20::1/64"  # Uncomment to enable IPv6
+# testing_network_ipv6_nat = true
 
-# Staging Network (default: 10.30.0.1/24)
-# staging_network_ipv4 = "10.30.0.1/24"
-# staging_network_nat  = true
+# Staging Network (default: 10.30.0.1/24, IPv6 disabled)
+# staging_network_ipv4     = "10.30.0.1/24"
+# staging_network_nat      = true
+# staging_network_ipv6     = "fd00:10:30::1/64"  # Uncomment to enable IPv6
+# staging_network_ipv6_nat = true
 
-# Production Network (default: 10.40.0.1/24)
-# production_network_ipv4 = "10.40.0.1/24"
-# production_network_nat  = true
+# Production Network (default: 10.40.0.1/24, IPv6 disabled)
+# production_network_ipv4     = "10.40.0.1/24"
+# production_network_nat      = true
+# production_network_ipv6     = "fd00:10:40::1/64"  # Uncomment to enable IPv6
+# production_network_ipv6_nat = true
 
-# Management Network (default: 10.50.0.1/24)
+# Management Network (default: 10.50.0.1/24, IPv6 disabled)
 # Hosts internal services like Grafana, Loki, Prometheus
-# management_network_ipv4 = "10.50.0.1/24"
-# management_network_nat  = true
+# management_network_ipv4     = "10.50.0.1/24"
+# management_network_nat      = true
+# management_network_ipv6     = "fd00:10:50::1/64"  # Uncomment to enable IPv6
+# management_network_ipv6_nat = true
 
 # ============================================================================
 # USAGE INSTRUCTIONS

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,6 +39,22 @@ variable "development_network_nat" {
   default     = true
 }
 
+variable "development_network_ipv6" {
+  description = "IPv6 address for development network (e.g., fd00:10:10::1/64). Set to empty string to disable IPv6."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.development_network_ipv6 == "" || can(cidrhost(var.development_network_ipv6, 0))
+    error_message = "Must be empty or valid IPv6 CIDR notation (e.g., fd00:10:10::1/64)"
+  }
+}
+
+variable "development_network_ipv6_nat" {
+  description = "Enable NAT for development network IPv6"
+  type        = bool
+  default     = true
+}
 
 # Testing Network Configuration
 variable "testing_network_ipv4" {
@@ -54,6 +70,23 @@ variable "testing_network_ipv4" {
 
 variable "testing_network_nat" {
   description = "Enable NAT for testing network IPv4"
+  type        = bool
+  default     = true
+}
+
+variable "testing_network_ipv6" {
+  description = "IPv6 address for testing network (e.g., fd00:10:20::1/64). Set to empty string to disable IPv6."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.testing_network_ipv6 == "" || can(cidrhost(var.testing_network_ipv6, 0))
+    error_message = "Must be empty or valid IPv6 CIDR notation (e.g., fd00:10:20::1/64)"
+  }
+}
+
+variable "testing_network_ipv6_nat" {
+  description = "Enable NAT for testing network IPv6"
   type        = bool
   default     = true
 }
@@ -76,6 +109,23 @@ variable "staging_network_nat" {
   default     = true
 }
 
+variable "staging_network_ipv6" {
+  description = "IPv6 address for staging network (e.g., fd00:10:30::1/64). Set to empty string to disable IPv6."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.staging_network_ipv6 == "" || can(cidrhost(var.staging_network_ipv6, 0))
+    error_message = "Must be empty or valid IPv6 CIDR notation (e.g., fd00:10:30::1/64)"
+  }
+}
+
+variable "staging_network_ipv6_nat" {
+  description = "Enable NAT for staging network IPv6"
+  type        = bool
+  default     = true
+}
+
 # Production Network Configuration
 variable "production_network_ipv4" {
   description = "IPv4 address for production network"
@@ -94,6 +144,23 @@ variable "production_network_nat" {
   default     = true
 }
 
+variable "production_network_ipv6" {
+  description = "IPv6 address for production network (e.g., fd00:10:40::1/64). Set to empty string to disable IPv6."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.production_network_ipv6 == "" || can(cidrhost(var.production_network_ipv6, 0))
+    error_message = "Must be empty or valid IPv6 CIDR notation (e.g., fd00:10:40::1/64)"
+  }
+}
+
+variable "production_network_ipv6_nat" {
+  description = "Enable NAT for production network IPv6"
+  type        = bool
+  default     = true
+}
+
 # Management Network Configuration
 variable "management_network_ipv4" {
   description = "IPv4 address for management network (monitoring, internal services)"
@@ -108,6 +175,23 @@ variable "management_network_ipv4" {
 
 variable "management_network_nat" {
   description = "Enable NAT for management network IPv4"
+  type        = bool
+  default     = true
+}
+
+variable "management_network_ipv6" {
+  description = "IPv6 address for management network (e.g., fd00:10:50::1/64). Set to empty string to disable IPv6."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.management_network_ipv6 == "" || can(cidrhost(var.management_network_ipv6, 0))
+    error_message = "Must be empty or valid IPv6 CIDR notation (e.g., fd00:10:50::1/64)"
+  }
+}
+
+variable "management_network_ipv6_nat" {
+  description = "Enable NAT for management network IPv6"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Summary
- Add IPv6 address variables for all five networks (development, testing, staging, production, management)
- Add IPv6 NAT configuration variables
- Update network resources with conditional IPv6 configuration using `merge()`
- Add IPv6 CIDR validation using `cidrhost()`
- Update terraform.tfvars.example with IPv6 examples
- Update CLAUDE.md with IPv6 documentation

## Design Decisions

**Disabled by default**: IPv6 is opt-in. Setting `*_network_ipv6` to empty string (default) disables IPv6 on that network.

**ULA addresses**: Uses fd00::/8 prefix for private addressing, matching the private IPv4 ranges (10.x.x.x).

**Conditional configuration**: Uses Terraform's `merge()` with ternary to cleanly add IPv6 config only when enabled.

## Example Usage

```hcl
# In terraform.tfvars
production_network_ipv6     = "fd00:10:40::1/64"
production_network_ipv6_nat = true
```

## Test plan
- [ ] Verify `tofu validate` passes
- [ ] Verify `tofu plan` shows no changes when IPv6 is disabled (default)
- [ ] Test enabling IPv6 on a single network
- [ ] Verify dual-stack connectivity when IPv6 is enabled

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)