### PR TITLE
feat: add Cloudflared module for Cloudflare Zero Trust tunnels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        service: [alertmanager, caddy, grafana, loki, mosquitto, prometheus, step-ca]
+        service: [alertmanager, caddy, cloudflared, grafana, loki, mosquitto, prometheus, step-ca]
       fail-fast: false
 
     steps:
@@ -126,6 +126,7 @@ jobs:
           echo "|---------|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| alertmanager | \`${{ env.IMAGE_PREFIX }}/alertmanager:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| caddy | \`${{ env.IMAGE_PREFIX }}/caddy:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| cloudflared | \`${{ env.IMAGE_PREFIX }}/cloudflared:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| grafana | \`${{ env.IMAGE_PREFIX }}/grafana:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| loki | \`${{ env.IMAGE_PREFIX }}/loki:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| mosquitto | \`${{ env.IMAGE_PREFIX }}/mosquitto:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
@@ -148,7 +149,7 @@ jobs:
 # NOTE: GitHub packages are private by default. To allow Incus to pull images
 # without authentication, you must manually set each package to public:
 #   1. Go to https://github.com/orgs/accuser/packages or your user packages page
-#   2. Click on each package (alertmanager, caddy, grafana, loki, mosquitto, prometheus, step-ca)
+#   2. Click on each package (alertmanager, caddy, cloudflared, grafana, loki, mosquitto, prometheus, step-ca)
 #   3. Go to Package settings
 #   4. Under "Danger Zone", change visibility to "Public"
 #

--- a/docker/cloudflared/Dockerfile
+++ b/docker/cloudflared/Dockerfile
@@ -1,0 +1,21 @@
+# Cloudflare Tunnel client for secure remote access
+# Uses the official cloudflared image
+FROM cloudflare/cloudflared:latest
+
+# OCI metadata labels for container management
+LABEL maintainer="hello@accuser.dev"
+LABEL description="Cloudflare Tunnel client for secure remote access via Zero Trust"
+LABEL org.opencontainers.image.source="https://github.com/accuser/atlas"
+LABEL org.opencontainers.image.title="Atlas Cloudflared"
+LABEL org.opencontainers.image.description="Cloudflare Tunnel client for Zero Trust remote access"
+LABEL org.opencontainers.image.vendor="accuser"
+
+# Health check using cloudflared's built-in ready endpoint
+# Note: Metrics server must be enabled (--metrics localhost:2000)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:2000/ready || exit 1
+
+# Default entrypoint runs the tunnel
+# Token is passed via TUNNEL_TOKEN environment variable
+ENTRYPOINT ["cloudflared", "tunnel"]
+CMD ["--metrics", "localhost:2000", "run"]

--- a/docker/cloudflared/README.md
+++ b/docker/cloudflared/README.md
@@ -1,0 +1,80 @@
+# Cloudflared Docker Image
+
+Custom Docker image for Cloudflare Tunnel client, providing secure remote access to internal services via Cloudflare Zero Trust.
+
+## Features
+
+- Based on official `cloudflare/cloudflared:latest` image
+- Token-based authentication (managed via Cloudflare dashboard)
+- Built-in metrics endpoint for Prometheus scraping
+- Health check for container monitoring
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `TUNNEL_TOKEN` | Cloudflare Tunnel token from Zero Trust dashboard | Yes |
+
+### Metrics Endpoint
+
+The container exposes a metrics endpoint at `localhost:2000` which provides:
+- `/ready` - Health check endpoint
+- `/metrics` - Prometheus metrics
+
+## Usage
+
+### Building Locally
+
+```bash
+# Build the image
+make build-cloudflared
+
+# Or with custom tag
+IMAGE_TAG=dev make build-cloudflared
+```
+
+### Running with Docker
+
+```bash
+docker run -d \
+  --name cloudflared \
+  -e TUNNEL_TOKEN="your-tunnel-token" \
+  ghcr.io/accuser/atlas/cloudflared:latest
+```
+
+### Cloudflare Zero Trust Setup
+
+1. Go to [Cloudflare Zero Trust Dashboard](https://one.dash.cloudflare.com/)
+2. Navigate to **Networks** > **Tunnels**
+3. Click **Create a tunnel**
+4. Choose **Cloudflared** connector
+5. Name your tunnel (e.g., `atlas-homelab`)
+6. Copy the tunnel token
+7. Configure public hostnames to route traffic to internal services
+
+### Example Tunnel Configuration
+
+In the Cloudflare dashboard, add public hostnames:
+
+| Public Hostname | Service | URL |
+|-----------------|---------|-----|
+| `grafana.example.com` | HTTP | `http://grafana01.incus:3000` |
+| `prometheus.example.com` | HTTP | `http://prometheus01.incus:9090` |
+
+## Integration with Atlas
+
+The cloudflared container connects to the management network and can reach all internal services:
+
+- Grafana: `http://grafana01.incus:3000`
+- Prometheus: `http://prometheus01.incus:9090`
+- Loki: `http://loki01.incus:3100`
+- Alertmanager: `http://alertmanager01.incus:9093`
+
+## Security Considerations
+
+- The tunnel token is sensitive and should be stored securely
+- Use Cloudflare Access policies to control who can access exposed services
+- Enable additional authentication (SSO, MFA) in Zero Trust settings
+- Consider IP allowlisting for additional security layers

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -364,3 +364,31 @@ module "mosquitto01" {
     incus_network.management
   ]
 }
+
+module "cloudflared01" {
+  source = "./modules/cloudflared"
+
+  count = var.cloudflared_tunnel_token != "" ? 1 : 0
+
+  instance_name = "cloudflared01"
+  profile_name  = "cloudflared"
+
+  # Network configuration - use management network to access internal services
+  network_name = incus_network.management.name
+
+  # Tunnel token from Cloudflare Zero Trust dashboard
+  tunnel_token = var.cloudflared_tunnel_token
+
+  # Resource limits - cloudflared is lightweight
+  cpu_limit    = "1"
+  memory_limit = "256MB"
+
+  # Ensure networks are created before the container
+  depends_on = [
+    incus_network.development,
+    incus_network.testing,
+    incus_network.staging,
+    incus_network.production,
+    incus_network.management
+  ]
+}

--- a/terraform/modules/cloudflared/main.tf
+++ b/terraform/modules/cloudflared/main.tf
@@ -1,0 +1,41 @@
+resource "incus_profile" "cloudflared" {
+  name = var.profile_name
+
+  config = {
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+    "boot.autorestart"      = "true"
+  }
+
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+    }
+  }
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network = var.network_name
+    }
+  }
+}
+
+resource "incus_instance" "cloudflared" {
+  name     = var.instance_name
+  image    = var.image
+  type     = "container"
+  profiles = ["default", incus_profile.cloudflared.name]
+
+  config = merge(
+    { for k, v in var.environment_variables : "environment.${k}" => v },
+    {
+      "environment.TUNNEL_TOKEN" = var.tunnel_token
+    },
+  )
+}

--- a/terraform/modules/cloudflared/outputs.tf
+++ b/terraform/modules/cloudflared/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_name" {
+  description = "Name of the created cloudflared instance"
+  value       = incus_instance.cloudflared.name
+}
+
+output "profile_name" {
+  description = "Name of the created profile"
+  value       = incus_profile.cloudflared.name
+}
+
+output "instance_status" {
+  description = "Status of the created cloudflared instance"
+  value       = incus_instance.cloudflared.status
+}
+
+output "metrics_endpoint" {
+  description = "Metrics endpoint URL for Prometheus scraping"
+  value       = "http://${var.instance_name}.incus:${var.metrics_port}"
+}

--- a/terraform/modules/cloudflared/variables.tf
+++ b/terraform/modules/cloudflared/variables.tf
@@ -1,0 +1,72 @@
+variable "instance_name" {
+  description = "Name of the cloudflared instance"
+  type        = string
+}
+
+variable "profile_name" {
+  description = "Name of the Incus profile"
+  type        = string
+}
+
+variable "image" {
+  description = "Container image to use"
+  type        = string
+  default     = "ghcr:accuser/atlas/cloudflared:latest"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the container"
+  type        = string
+  default     = "1"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the container"
+  type        = string
+  default     = "256MB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '256MB' or '1GB'"
+  }
+}
+
+variable "storage_pool" {
+  description = "Storage pool for the root disk"
+  type        = string
+  default     = "local"
+}
+
+variable "network_name" {
+  description = "Network name to connect the container to"
+  type        = string
+  default     = "management"
+}
+
+variable "environment_variables" {
+  description = "Environment variables for cloudflared container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tunnel_token" {
+  description = "Cloudflare Tunnel token from Zero Trust dashboard"
+  type        = string
+  sensitive   = true
+}
+
+variable "metrics_port" {
+  description = "Port for the metrics endpoint"
+  type        = string
+  default     = "2000"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.metrics_port)) && tonumber(var.metrics_port) >= 1 && tonumber(var.metrics_port) <= 65535
+    error_message = "Port must be a number between 1 and 65535"
+  }
+}

--- a/terraform/modules/cloudflared/versions.tf
+++ b/terraform/modules/cloudflared/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    incus = {
+      source = "lxc/incus"
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -50,3 +50,13 @@ output "mosquitto_external_ports" {
     mqtts = module.mosquitto01.external_mqtts_port
   }
 }
+
+output "cloudflared_metrics_endpoint" {
+  description = "Cloudflared metrics endpoint URL (if enabled)"
+  value       = length(module.cloudflared01) > 0 ? module.cloudflared01[0].metrics_endpoint : null
+}
+
+output "cloudflared_instance_status" {
+  description = "Cloudflared instance status (if enabled)"
+  value       = length(module.cloudflared01) > 0 ? module.cloudflared01[0].instance_status : null
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -195,3 +195,11 @@ variable "management_network_ipv6_nat" {
   type        = bool
   default     = true
 }
+
+# Cloudflared Configuration
+variable "cloudflared_tunnel_token" {
+  description = "Cloudflare Tunnel token from Zero Trust dashboard"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Add cloudflared Docker image based on official `cloudflare/cloudflared` with health check
- Add Terraform module for Cloudflare Tunnel client with token-based authentication
- Module is conditionally deployed only when `cloudflared_tunnel_token` is provided
- Container connects to management network for internal service access
- Metrics endpoint exposed at port 2000 for Prometheus scraping

## Usage

1. Create a tunnel in [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/)
2. Add token to `terraform.tfvars`:
   ```hcl
   cloudflared_tunnel_token = "eyJ..."
   ```
3. Configure public hostnames in Cloudflare to route to internal services (e.g., `http://grafana01.incus:3000`)
4. Deploy with `make deploy`

## Test plan

- [ ] Verify Terraform validates successfully
- [ ] Deploy with tunnel token and confirm container starts
- [ ] Test remote access to Grafana via Cloudflare tunnel
- [ ] Verify metrics endpoint is accessible for Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)