### PR TITLE
feat: add incus-loki module for native Incus logging to Loki

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ atlas/
 │   │   ├── caddy/
 │   │   ├── cloudflared/
 │   │   ├── grafana/
+│   │   ├── incus-loki/
 │   │   ├── incus-metrics/
 │   │   ├── loki/
 │   │   ├── mosquitto/
@@ -511,6 +512,20 @@ The project uses Terraform modules for scalability and reusability:
     - Certificate validity: 10 years (3650 days)
     - Conditionally deployed: Only created when `enable_incus_metrics` is true (default)
     - Provides container-level metrics: CPU, memory, disk, network, processes
+
+21. **Incus Loki Module** ([terraform/modules/incus-loki/](terraform/modules/incus-loki/))
+    - Configures native Incus logging to Loki (no Promtail required)
+    - Pushes lifecycle events (instance start/stop, create, delete)
+    - Pushes logging events (container and VM log output)
+    - Uses Incus server-level configuration
+    - No Docker image required (server configuration only)
+
+22. **Incus Loki** (instantiated in [terraform/main.tf](terraform/main.tf))
+    - Logging name: `loki01`
+    - Target address: `http://loki01.incus:3100`
+    - Event types: `lifecycle,logging`
+    - Conditionally deployed: Only created when `enable_incus_loki` is true (default)
+    - Logs queryable in Grafana via Loki datasource
 
 ### External TCP Service Pattern (Proxy Devices)
 
@@ -1253,3 +1268,5 @@ After applying, use `cd terraform && tofu output` to view:
 - `cloudflared_instance_status` - Cloudflared instance status (if enabled)
 - `incus_metrics_endpoint` - Incus metrics endpoint URL being scraped by Prometheus
 - `incus_metrics_certificate_fingerprint` - Fingerprint of the metrics certificate registered with Incus
+- `incus_loki_logging_name` - Name of the Incus logging configuration for Loki
+- `incus_loki_address` - Loki address configured for Incus logging

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -421,3 +421,19 @@ module "incus_metrics" {
   certificate_description = "Metrics certificate for Prometheus to scrape Incus container metrics"
   incus_server_address    = var.incus_metrics_address
 }
+
+module "incus_loki" {
+  source = "./modules/incus-loki"
+
+  count = var.enable_incus_loki ? 1 : 0
+
+  logging_name = "loki01"
+  # Use IP-based endpoint because Incus daemon runs on host and cannot resolve .incus DNS
+  loki_address = module.loki01.loki_endpoint_ip
+
+  # Send lifecycle and logging events to Loki
+  log_types = "lifecycle,logging"
+
+  # Ensure Loki is running before configuring logging
+  depends_on = [module.loki01]
+}

--- a/terraform/modules/incus-loki/README.md
+++ b/terraform/modules/incus-loki/README.md
@@ -1,0 +1,112 @@
+# Incus Loki Module
+
+This module configures Incus to natively push logs to a Loki server, eliminating the need for external log shippers like Promtail.
+
+## Overview
+
+Incus has built-in support for sending logs directly to Loki. This module configures the Incus server with the appropriate logging target settings. Once configured, Incus will push:
+
+- **Lifecycle events** - Instance start/stop, creation, deletion, snapshots, etc.
+- **Logging events** - Container and VM log output
+- **Network ACL events** - Network access control list activity
+
+## Usage
+
+```hcl
+module "incus_loki" {
+  source = "./modules/incus-loki"
+
+  logging_name = "loki01"
+  loki_address = "http://loki01.incus:3100"
+  log_types    = "lifecycle,logging"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| incus | >= 1.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `logging_name` | Unique name for the logging target | `string` | `"loki01"` |
+| `loki_address` | Loki server address with protocol and port | `string` | **required** |
+| `log_types` | Event types to send (lifecycle, logging, network-acl) | `string` | `"lifecycle,logging"` |
+| `labels` | Labels to include in Loki log entries | `string` | `""` |
+| `instance_name` | Instance field value in Loki events | `string` | `""` (hostname) |
+| `retry_count` | Number of delivery retry attempts | `number` | `3` |
+| `username` | Username for Loki authentication | `string` | `""` |
+| `password` | Password for Loki authentication | `string` | `""` |
+| `ca_cert` | CA certificate for HTTPS connections | `string` | `""` |
+| `lifecycle_types` | Instance types for lifecycle events | `string` | `""` (all) |
+| `lifecycle_projects` | Projects for lifecycle events | `string` | `""` (all) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `logging_name` | Name of the logging configuration |
+| `loki_address` | Loki server address being used |
+| `log_types` | Event types being sent to Loki |
+| `config_keys` | List of Incus server config keys that were set |
+
+## Log Types
+
+| Type | Description |
+|------|-------------|
+| `lifecycle` | Instance lifecycle events (start, stop, create, delete, etc.) |
+| `logging` | Container and VM log output |
+| `network-acl` | Network ACL rule matches and actions |
+
+## Querying Logs in Grafana
+
+Once configured, logs will appear in Grafana's Explore view with the Loki datasource:
+
+```logql
+{job="incus"}
+```
+
+Filter by event type:
+```logql
+{job="incus", type="lifecycle"}
+```
+
+Filter by instance:
+```logql
+{job="incus", instance=~".*grafana.*"}
+```
+
+## Verification
+
+Check if logging is configured:
+```bash
+incus config show | grep logging
+```
+
+View logs in Loki:
+```bash
+incus exec loki01 -- wget -q -O - 'http://localhost:3100/loki/api/v1/labels'
+```
+
+## Notes
+
+- Incus pushes logs directly to Loki's HTTP API (`/loki/api/v1/push`)
+- No external log shipper (Promtail, Alloy) is required
+- Logs are pushed in real-time as events occur
+- The configuration is applied at the Incus server level (global scope)
+- Multiple logging targets can be configured with different names
+
+## Important: Address Resolution
+
+**The Incus daemon runs on the host**, not inside containers. This means:
+- It **cannot** resolve `.incus` DNS names (e.g., `loki01.incus`)
+- You must use the **IP address** of the Loki container
+- Use `module.loki01.loki_endpoint_ip` instead of `module.loki01.loki_endpoint`
+
+If you see no logs in Loki, check the address configuration:
+```bash
+incus config show | grep logging
+```

--- a/terraform/modules/incus-loki/main.tf
+++ b/terraform/modules/incus-loki/main.tf
@@ -1,0 +1,41 @@
+locals {
+  # Build the configuration map for Incus server logging
+  # Only include non-empty values to avoid setting unnecessary config
+  base_config = {
+    "logging.${var.logging_name}.target.type"    = "loki"
+    "logging.${var.logging_name}.target.address" = var.loki_address
+    "logging.${var.logging_name}.types"          = var.log_types
+    "logging.${var.logging_name}.target.retry"   = tostring(var.retry_count)
+  }
+
+  optional_config = merge(
+    var.labels != "" ? {
+      "logging.${var.logging_name}.target.labels" = var.labels
+    } : {},
+    var.instance_name != "" ? {
+      "logging.${var.logging_name}.target.instance" = var.instance_name
+    } : {},
+    var.username != "" ? {
+      "logging.${var.logging_name}.target.username" = var.username
+    } : {},
+    var.password != "" ? {
+      "logging.${var.logging_name}.target.password" = var.password
+    } : {},
+    var.ca_cert != "" ? {
+      "logging.${var.logging_name}.target.ca_cert" = var.ca_cert
+    } : {},
+    var.lifecycle_types != "" ? {
+      "logging.${var.logging_name}.lifecycle.types" = var.lifecycle_types
+    } : {},
+    var.lifecycle_projects != "" ? {
+      "logging.${var.logging_name}.lifecycle.projects" = var.lifecycle_projects
+    } : {},
+  )
+
+  full_config = merge(local.base_config, local.optional_config)
+}
+
+# Configure Incus server to send logs to Loki
+resource "incus_server" "logging" {
+  config = local.full_config
+}

--- a/terraform/modules/incus-loki/outputs.tf
+++ b/terraform/modules/incus-loki/outputs.tf
@@ -1,0 +1,19 @@
+output "logging_name" {
+  description = "Name of the logging configuration"
+  value       = var.logging_name
+}
+
+output "loki_address" {
+  description = "Address of the Loki server being used"
+  value       = var.loki_address
+}
+
+output "log_types" {
+  description = "Event types being sent to Loki"
+  value       = var.log_types
+}
+
+output "config_keys" {
+  description = "List of Incus server config keys that were set"
+  value       = keys(local.full_config)
+}

--- a/terraform/modules/incus-loki/variables.tf
+++ b/terraform/modules/incus-loki/variables.tf
@@ -1,0 +1,87 @@
+variable "logging_name" {
+  description = "Unique name for the logging target configuration (e.g., 'loki01')"
+  type        = string
+  default     = "loki01"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.logging_name))
+    error_message = "Logging name must start with a letter and contain only lowercase letters, numbers, and hyphens"
+  }
+}
+
+variable "loki_address" {
+  description = "Address of the Loki server including protocol and port (e.g., 'http://loki01.incus:3100')"
+  type        = string
+
+  validation {
+    condition     = can(regex("^https?://", var.loki_address))
+    error_message = "Loki address must start with http:// or https://"
+  }
+}
+
+variable "log_types" {
+  description = "Comma-separated list of event types to send to Loki (lifecycle, logging, network-acl)"
+  type        = string
+  default     = "lifecycle,logging"
+
+  validation {
+    condition     = alltrue([for t in split(",", var.log_types) : contains(["lifecycle", "logging", "network-acl"], trimspace(t))])
+    error_message = "Log types must be comma-separated list of: lifecycle, logging, network-acl"
+  }
+}
+
+variable "labels" {
+  description = "Comma-separated list of labels to include in Loki log entries"
+  type        = string
+  default     = ""
+}
+
+variable "instance_name" {
+  description = "Name to use as the instance field in Loki events (defaults to server hostname)"
+  type        = string
+  default     = ""
+}
+
+variable "retry_count" {
+  description = "Number of delivery retry attempts"
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.retry_count >= 1 && var.retry_count <= 10
+    error_message = "Retry count must be between 1 and 10"
+  }
+}
+
+variable "username" {
+  description = "Username for Loki authentication (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "password" {
+  description = "Password for Loki authentication (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ca_cert" {
+  description = "CA certificate for TLS verification (optional, for HTTPS connections)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "lifecycle_types" {
+  description = "Comma-separated list of instance types for lifecycle events (empty for all)"
+  type        = string
+  default     = ""
+}
+
+variable "lifecycle_projects" {
+  description = "Comma-separated list of projects for lifecycle events (empty for all)"
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/incus-loki/versions.tf
+++ b/terraform/modules/incus-loki/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -19,8 +19,18 @@ output "storage_volume_name" {
 }
 
 output "loki_endpoint" {
-  description = "Loki endpoint URL for internal use"
+  description = "Loki endpoint URL for internal use (using .incus DNS)"
   value       = "${var.enable_tls ? "https" : "http"}://${var.instance_name}.incus:${var.loki_port}"
+}
+
+output "loki_endpoint_ip" {
+  description = "Loki endpoint URL using IP address (for host-level access)"
+  value       = "${var.enable_tls ? "https" : "http"}://${incus_instance.loki.ipv4_address}:${var.loki_port}"
+}
+
+output "ipv4_address" {
+  description = "IPv4 address of the Loki instance"
+  value       = incus_instance.loki.ipv4_address
 }
 
 output "tls_enabled" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -70,3 +70,13 @@ output "incus_metrics_certificate_fingerprint" {
   description = "Fingerprint of the metrics certificate registered with Incus"
   value       = var.enable_incus_metrics ? module.incus_metrics[0].certificate_fingerprint : null
 }
+
+output "incus_loki_logging_name" {
+  description = "Name of the Incus logging configuration for Loki"
+  value       = var.enable_incus_loki ? module.incus_loki[0].logging_name : null
+}
+
+output "incus_loki_address" {
+  description = "Loki address configured for Incus logging"
+  value       = var.enable_incus_loki ? module.incus_loki[0].loki_address : null
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -216,3 +216,9 @@ variable "enable_incus_metrics" {
   type        = bool
   default     = true
 }
+
+variable "enable_incus_loki" {
+  description = "Enable native Incus logging to Loki (sends lifecycle and logging events)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- Add new `terraform/modules/incus-loki/` module that configures Incus to natively push logs to Loki
- No Promtail or external log shipper required - Incus pushes directly to Loki's HTTP API
- Add `loki_endpoint_ip` output to Loki module (required for host-level Incus daemon access)
- Supports lifecycle events (instance start/stop, create, delete) and logging events (container output)

## Important Notes
The Incus daemon runs on the host and cannot resolve `.incus` DNS names. The module uses the Loki container's IP address via `module.loki01.loki_endpoint_ip`.

## Test plan
- [x] Run `tofu validate` - configuration is valid
- [x] Run `tofu apply` - module configures Incus logging
- [x] Verify `incus config show | grep logging` shows correct configuration
- [x] Query Loki labels - confirmed `lifecycle` and `logging` event types present
- [x] Verify logs appear in Grafana via Loki datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)