### PR TITLE
feat: add node-exporter Docker image for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,16 @@ jobs:
             step_ca:
               - 'docker/step-ca/**'
               - 'test/docker/step-ca_test.sh'
+            node_exporter:
+              - 'docker/node-exporter/**'
+              - 'test/docker/node-exporter_test.sh'
 
       - name: Build matrix
         id: set-matrix
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # PRs: Build all images for full validation
-            echo 'matrix=["alertmanager","caddy","cloudflared","grafana","loki","mosquitto","prometheus","step-ca"]' >> $GITHUB_OUTPUT
+            echo 'matrix=["alertmanager","caddy","cloudflared","grafana","loki","mosquitto","node-exporter","prometheus","step-ca"]' >> $GITHUB_OUTPUT
             echo 'has_changes=true' >> $GITHUB_OUTPUT
             echo "📋 PR detected - will build all images"
           else
@@ -135,6 +138,7 @@ jobs:
             if [ "${{ steps.filter.outputs.mosquitto }}" == "true" ]; then SERVICES+=("mosquitto"); fi
             if [ "${{ steps.filter.outputs.prometheus }}" == "true" ]; then SERVICES+=("prometheus"); fi
             if [ "${{ steps.filter.outputs.step_ca }}" == "true" ]; then SERVICES+=("step-ca"); fi
+            if [ "${{ steps.filter.outputs.node_exporter }}" == "true" ]; then SERVICES+=("node-exporter"); fi
 
             if [ ${#SERVICES[@]} -eq 0 ]; then
               echo 'matrix=[]' >> $GITHUB_OUTPUT
@@ -169,6 +173,7 @@ jobs:
             echo "| mosquitto | ${{ steps.filter.outputs.mosquitto == 'true' && '✅' || '—' }} |" >> $GITHUB_STEP_SUMMARY
             echo "| prometheus | ${{ steps.filter.outputs.prometheus == 'true' && '✅' || '—' }} |" >> $GITHUB_STEP_SUMMARY
             echo "| step-ca | ${{ steps.filter.outputs.step_ca == 'true' && '✅' || '—' }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| node-exporter | ${{ steps.filter.outputs.node_exporter == 'true' && '✅' || '—' }} |" >> $GITHUB_STEP_SUMMARY
           fi
 
   # =============================================================================

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        package: [alertmanager, caddy, cloudflared, grafana, loki, mosquitto, prometheus, step-ca]
+        package: [alertmanager, caddy, cloudflared, grafana, loki, mosquitto, node-exporter, prometheus, step-ca]
       fail-fast: false
 
     steps:
@@ -66,6 +66,7 @@ jobs:
           echo "| atlas/grafana | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| atlas/loki | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| atlas/mosquitto | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| atlas/node-exporter | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| atlas/prometheus | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| atlas/step-ca | ${{ needs.cleanup.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        service: [alertmanager, caddy, cloudflared, grafana, loki, mosquitto, prometheus, step-ca]
+        service: [alertmanager, caddy, cloudflared, grafana, loki, mosquitto, node-exporter, prometheus, step-ca]
       fail-fast: false
 
     steps:
@@ -130,6 +130,7 @@ jobs:
           echo "| grafana | \`${{ env.IMAGE_PREFIX }}/grafana:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| loki | \`${{ env.IMAGE_PREFIX }}/loki:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| mosquitto | \`${{ env.IMAGE_PREFIX }}/mosquitto:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| node-exporter | \`${{ env.IMAGE_PREFIX }}/node-exporter:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| prometheus | \`${{ env.IMAGE_PREFIX }}/prometheus:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| step-ca | \`${{ env.IMAGE_PREFIX }}/step-ca:latest\` | ${{ needs.docker-release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -149,7 +150,7 @@ jobs:
 # NOTE: GitHub packages are private by default. To allow Incus to pull images
 # without authentication, you must manually set each package to public:
 #   1. Go to https://github.com/orgs/accuser/packages or your user packages page
-#   2. Click on each package (alertmanager, caddy, cloudflared, grafana, loki, mosquitto, prometheus, step-ca)
+#   2. Click on each package (alertmanager, caddy, cloudflared, grafana, loki, mosquitto, node-exporter, prometheus, step-ca)
 #   3. Go to Package settings
 #   4. Under "Danger Zone", change visibility to "Public"
 #

--- a/docker/node-exporter/Dockerfile
+++ b/docker/node-exporter/Dockerfile
@@ -1,0 +1,22 @@
+# Node Exporter for host-level metrics collection
+# Pinned to v1.10.2 for reproducibility
+FROM prom/node-exporter:v1.10.2
+
+# OCI metadata labels for container management
+LABEL maintainer="hello@accuser.dev"
+LABEL description="Node Exporter for host-level metrics collection"
+LABEL org.opencontainers.image.source="https://github.com/accuser/atlas"
+LABEL org.opencontainers.image.version="1.10.2"
+LABEL org.opencontainers.image.title="Atlas Node Exporter"
+LABEL org.opencontainers.image.description="Prometheus node exporter for host system metrics (CPU, memory, disk, network)"
+LABEL org.opencontainers.image.vendor="accuser"
+
+# Health check using the metrics endpoint
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:9100/metrics || exit 1
+
+# Default entrypoint from upstream image
+# Container expects host paths mounted:
+#   --path.rootfs=/host (for filesystem metrics)
+#   --path.procfs=/host/proc (for process metrics)
+#   --path.sysfs=/host/sys (for system metrics)

--- a/terraform/modules/node-exporter/variables.tf
+++ b/terraform/modules/node-exporter/variables.tf
@@ -11,7 +11,7 @@ variable "profile_name" {
 variable "image" {
   description = "Container image to use"
   type        = string
-  default     = "docker:prom/node-exporter:latest"
+  default     = "ghcr:accuser/atlas/node-exporter:latest"
 }
 
 variable "cpu_limit" {

--- a/test/docker/node-exporter_test.sh
+++ b/test/docker/node-exporter_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Smoke tests for Node Exporter container
+# Tests: image inspection, startup, version, labels
+set -euo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/accuser/atlas/node-exporter:latest}"
+CONTAINER_NAME="node-exporter-test-${GITHUB_RUN_ID:-local}"
+
+cleanup() {
+  echo "Cleaning up..."
+  docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "========================================="
+echo "Testing Node Exporter container: ${IMAGE}"
+echo "========================================="
+
+# Test 1: Container image exists and can be inspected
+echo ""
+echo "Test 1: Image inspection..."
+if ! docker inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "❌ Image cannot be inspected"
+  exit 1
+fi
+echo "✅ Image exists and can be inspected"
+
+# Test 2: Node Exporter version command works
+echo ""
+echo "Test 2: Node Exporter version..."
+VERSION=$(docker run --rm "${IMAGE}" --version 2>&1 || true)
+if [[ ! "${VERSION}" =~ node_exporter ]]; then
+  echo "❌ Node Exporter version command failed"
+  echo "Output: ${VERSION}"
+  exit 1
+fi
+echo "✅ Node Exporter version: ${VERSION}"
+
+# Test 3: Container starts successfully
+echo ""
+echo "Test 3: Container startup..."
+docker run -d --name "${CONTAINER_NAME}" "${IMAGE}"
+sleep 3
+# Check container is running
+if ! docker ps --filter "name=${CONTAINER_NAME}" --filter "status=running" | grep -q "${CONTAINER_NAME}"; then
+  echo "❌ Container is not running"
+  docker logs "${CONTAINER_NAME}"
+  exit 1
+fi
+echo "✅ Container started and running"
+
+# Test 4: Node Exporter is listening (check logs for startup message)
+echo ""
+echo "Test 4: Node Exporter listening..."
+LOGS=$(docker logs "${CONTAINER_NAME}" 2>&1)
+if ! echo "${LOGS}" | grep -q "Listening on"; then
+  echo "❌ Node Exporter not listening (no startup message in logs)"
+  echo "Logs: ${LOGS}"
+  exit 1
+fi
+echo "✅ Node Exporter is listening"
+
+# Test 5: Check container labels
+echo ""
+echo "Test 5: Container labels..."
+LABEL=$(docker inspect --format '{{index .Config.Labels "org.opencontainers.image.title"}}' "${IMAGE}")
+if [ -z "${LABEL}" ]; then
+  echo "⚠️  OCI title label not set (optional)"
+else
+  echo "✅ OCI title label: ${LABEL}"
+fi
+
+# Test 6: Health check is configured
+echo ""
+echo "Test 6: Health check configuration..."
+HEALTHCHECK=$(docker inspect --format '{{json .Config.Healthcheck}}' "${IMAGE}")
+if [ "${HEALTHCHECK}" = "null" ] || [ -z "${HEALTHCHECK}" ]; then
+  echo "❌ No health check configured"
+  exit 1
+fi
+echo "✅ Health check configured: ${HEALTHCHECK}"
+
+echo ""
+echo "========================================="
+echo "✅ All Node Exporter container tests passed!"
+echo "========================================="


### PR DESCRIPTION
## Summary

- Create `docker/node-exporter/Dockerfile` based on `prom/node-exporter:v1.10.2`
- Add OCI metadata labels matching other Atlas images
- Add health check for metrics endpoint
- Add node-exporter to CI, release, and cleanup workflows
- Create smoke test script for node-exporter container
- Update Terraform module to use custom image from ghcr.io

## Context

The node-exporter Terraform module existed but there was no custom Docker image in the `docker/` directory. This was inconsistent with other services and meant node-exporter wasn't included in CI/CD image builds.

## Test plan

- [x] Docker image builds successfully
- [x] All smoke tests pass locally
- [ ] CI pipeline passes (build, test, security scan)

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)