### PR TITLE
fix: remove unused sensitive variables from incus-loki module

### DIFF
--- a/terraform/modules/incus-loki/main.tf
+++ b/terraform/modules/incus-loki/main.tf
@@ -15,15 +15,6 @@ locals {
     var.instance_name != "" ? {
       "logging.${var.logging_name}.target.instance" = var.instance_name
     } : {},
-    var.username != "" ? {
-      "logging.${var.logging_name}.target.username" = var.username
-    } : {},
-    var.password != "" ? {
-      "logging.${var.logging_name}.target.password" = var.password
-    } : {},
-    var.ca_cert != "" ? {
-      "logging.${var.logging_name}.target.ca_cert" = var.ca_cert
-    } : {},
     var.lifecycle_types != "" ? {
       "logging.${var.logging_name}.lifecycle.types" = var.lifecycle_types
     } : {},

--- a/terraform/modules/incus-loki/variables.tf
+++ b/terraform/modules/incus-loki/variables.tf
@@ -53,27 +53,6 @@ variable "retry_count" {
   }
 }
 
-variable "username" {
-  description = "Username for Loki authentication (optional)"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "password" {
-  description = "Password for Loki authentication (optional)"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "ca_cert" {
-  description = "CA certificate for TLS verification (optional, for HTTPS connections)"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "lifecycle_types" {
   description = "Comma-separated list of instance types for lifecycle events (empty for all)"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -224,7 +224,7 @@ variable "incus_metrics_server_name" {
 }
 
 variable "enable_incus_loki" {
-  description = "Enable native Incus logging to Loki (sends lifecycle and logging events)"
+  description = "Enable native Incus logging to Loki (sends lifecycle and logging events). Currently disabled by default due to Incus provider bug - see issue #135."
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
## Summary

- Remove `username`, `password`, and `ca_cert` variables from the incus-loki module (unused since Loki is internal)
- **Disable the module by default** (`enable_incus_loki = false`) due to Incus provider bugs

## Problem

When applying changes to the incus-loki module, the Incus provider produces inconsistent results. See issue #135 for full details.

## Solution

1. Remove unused sensitive variables
2. Disable the module by default until the provider is fixed
3. Users can still configure Incus logging manually via CLI

## Test plan

- [x] `tofu validate` passes
- [ ] CI passes
- [ ] Apply succeeds with module disabled

Relates to #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)