### PR TITLE
fix: configure node-exporter to use host path mounts

### DIFF
--- a/docker/node-exporter/Dockerfile
+++ b/docker/node-exporter/Dockerfile
@@ -15,8 +15,10 @@ LABEL org.opencontainers.image.vendor="accuser"
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:9100/metrics || exit 1
 
-# Default entrypoint from upstream image
-# Container expects host paths mounted:
-#   --path.rootfs=/host (for filesystem metrics)
-#   --path.procfs=/host/proc (for process metrics)
-#   --path.sysfs=/host/sys (for system metrics)
+# Configure node_exporter to use mounted host paths
+# The Terraform module mounts:
+#   / -> /host (host root filesystem)
+#   /proc -> /host/proc (process info)
+#   /sys -> /host/sys (system info)
+ENTRYPOINT ["/bin/node_exporter"]
+CMD ["--path.rootfs=/host", "--path.procfs=/host/proc", "--path.sysfs=/host/sys"]

--- a/test/docker/node-exporter_test.sh
+++ b/test/docker/node-exporter_test.sh
@@ -37,9 +37,11 @@ fi
 echo "✅ Node Exporter version: ${VERSION}"
 
 # Test 3: Container starts successfully
+# Note: The image has default args for Incus host mounts (--path.rootfs=/host etc.)
+# For Docker testing, we override with empty args to run with container-local paths
 echo ""
 echo "Test 3: Container startup..."
-docker run -d --name "${CONTAINER_NAME}" "${IMAGE}"
+docker run -d --name "${CONTAINER_NAME}" "${IMAGE}" --path.rootfs=/ --path.procfs=/proc --path.sysfs=/sys
 sleep 3
 # Check container is running
 if ! docker ps --filter "name=${CONTAINER_NAME}" --filter "status=running" | grep -q "${CONTAINER_NAME}"; then


### PR DESCRIPTION
## Summary

- Configure node-exporter to use mounted host paths for accurate host metrics
- Update test script to work in Docker environment

## Problem

The node-exporter container was starting with default arguments, which meant it was reporting metrics from inside the container rather than from the host system. The Terraform module correctly mounts `/`, `/proc`, and `/sys` to `/host`, `/host/proc`, and `/host/sys`, but node-exporter wasn't being told to use these paths.

## Solution

- Added explicit `ENTRYPOINT` and `CMD` to the Dockerfile with:
  - `--path.rootfs=/host` - for filesystem metrics
  - `--path.procfs=/host/proc` - for process metrics  
  - `--path.sysfs=/host/sys` - for system metrics

- Updated test script to override these paths for Docker testing (where the host mounts are not available)

## Test plan

- [x] Docker image builds successfully
- [x] All smoke tests pass
- [ ] Verify metrics appear in Grafana after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)