### PR TITLE
feat: add minimum size validation for storage volumes

### DIFF
--- a/terraform/modules/alertmanager/variables.tf
+++ b/terraform/modules/alertmanager/variables.tf
@@ -67,13 +67,22 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 1GB)"
+  description = "Size of the storage volume (e.g., 1GB). Minimum recommended: 100MB"
   type        = string
   default     = "1GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '1GB' or '500MB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("TB$", var.data_volume_size)) ||
+      can(regex("GB$", var.data_volume_size)) ||
+      (can(regex("MB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 100)
+    )
+    error_message = "Alertmanager volume size must be at least 100MB for silences and state"
   }
 }
 

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -67,13 +67,22 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 10GB)"
+  description = "Size of the storage volume (e.g., 10GB). Minimum recommended: 1GB"
   type        = string
   default     = "10GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '10GB' or '100MB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("TB$", var.data_volume_size)) ||
+      (can(regex("GB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 1) ||
+      (can(regex("MB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 1024)
+    )
+    error_message = "Grafana volume size must be at least 1GB (or 1024MB) for reliable operation"
   }
 }
 

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -67,13 +67,21 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 50GB)"
+  description = "Size of the storage volume (e.g., 50GB). Minimum recommended: 10GB"
   type        = string
   default     = "50GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '50GB' or '100MB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("TB$", var.data_volume_size)) ||
+      (can(regex("GB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 10)
+    )
+    error_message = "Loki volume size must be at least 10GB for log storage"
   }
 }
 

--- a/terraform/modules/mosquitto/variables.tf
+++ b/terraform/modules/mosquitto/variables.tf
@@ -67,13 +67,22 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 5GB)"
+  description = "Size of the storage volume (e.g., 5GB). Minimum recommended: 100MB"
   type        = string
   default     = "5GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '5GB' or '500MB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("TB$", var.data_volume_size)) ||
+      can(regex("GB$", var.data_volume_size)) ||
+      (can(regex("MB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 100)
+    )
+    error_message = "Mosquitto volume size must be at least 100MB for retained messages"
   }
 }
 

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -67,13 +67,21 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 100GB)"
+  description = "Size of the storage volume (e.g., 100GB). Minimum recommended: 10GB"
   type        = string
   default     = "100GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB|TB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '100GB' or '1TB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("TB$", var.data_volume_size)) ||
+      (can(regex("GB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 10)
+    )
+    error_message = "Prometheus volume size must be at least 10GB for metrics storage"
   }
 }
 

--- a/terraform/modules/step-ca/variables.tf
+++ b/terraform/modules/step-ca/variables.tf
@@ -91,13 +91,21 @@ variable "data_volume_name" {
 }
 
 variable "data_volume_size" {
-  description = "Size of the storage volume (e.g., 1GB)"
+  description = "Size of the storage volume (e.g., 1GB). Minimum recommended: 100MB"
   type        = string
   default     = "1GB"
 
   validation {
     condition     = can(regex("^[0-9]+(MB|GB)$", var.data_volume_size))
     error_message = "Volume size must be in format like '1GB' or '500MB'"
+  }
+
+  validation {
+    condition = (
+      can(regex("GB$", var.data_volume_size)) ||
+      (can(regex("MB$", var.data_volume_size)) && tonumber(regex("^[0-9]+", var.data_volume_size)) >= 100)
+    )
+    error_message = "step-ca volume size must be at least 100MB for CA data and certificates"
   }
 }
 


### PR DESCRIPTION
## Summary

Adds service-specific minimum size validation to the `data_volume_size` variable in all modules that support persistent storage. This prevents deployment issues from undersized volumes.

## Changes

| Module | Minimum Size | Reason |
|--------|--------------|--------|
| Grafana | 1GB | Dashboards and data |
| Prometheus | 10GB | Metrics storage |
| Loki | 10GB | Log storage |
| Alertmanager | 100MB | Silences and state |
| step-ca | 100MB | CA data and certificates |
| Mosquitto | 100MB | Retained messages |

## Implementation

Each module now has two validation blocks:
1. **Format validation** (existing): Ensures format matches `<number>(MB|GB|TB)`
2. **Minimum size validation** (new): Ensures size meets service-specific minimum

Example error when validation fails:
```
Error: Invalid value for variable

  on modules/prometheus/variables.tf line 69:
  69: variable "data_volume_size" {

Prometheus volume size must be at least 10GB for metrics storage
```

## Test plan

- [x] `tofu validate` passes
- [x] `tofu fmt` applied

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)