### PR TITLE
fix: use flat path for Grafana dashboard provisioning

### DIFF
--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -109,7 +109,7 @@ resource "incus_instance" "grafana" {
     for_each = var.enable_default_dashboards ? [1] : []
     content {
       content     = file("${path.module}/dashboards/atlas-health.json")
-      target_path = "/etc/grafana/provisioning/dashboards/json/atlas-health.json"
+      target_path = "/etc/grafana/provisioning/dashboards/atlas-health.json"
       mode        = "0644"
     }
   }

--- a/terraform/modules/grafana/templates/dashboards.yaml.tftpl
+++ b/terraform/modules/grafana/templates/dashboards.yaml.tftpl
@@ -12,4 +12,4 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:
-      path: /etc/grafana/provisioning/dashboards/json
+      path: /etc/grafana/provisioning/dashboards


### PR DESCRIPTION
## Summary
- Changed dashboard provisioning path from `/etc/grafana/provisioning/dashboards/json/` to `/etc/grafana/provisioning/dashboards/`
- Incus file provisioning doesn't create parent directories, causing the nested path to fail

## Test plan
- [ ] Run `make deploy` to verify Grafana container starts successfully
- [ ] Verify the Atlas Health dashboard appears in Grafana under the Atlas folder

Fixes deployment error from #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)