### PR TITLE
feat: make allowed_ip_range configurable via variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,7 +34,7 @@ module "grafana01" {
 
   # Domain configuration for reverse proxy
   domain           = "grafana.accuser.dev"
-  allowed_ip_range = "192.168.68.0/22"
+  allowed_ip_range = var.allowed_ip_range
   grafana_port     = "3000"
 
   # Environment variables for Grafana configuration

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -17,6 +17,14 @@ cloudflare_api_token = "your-cloudflare-api-token-here"
 grafana_admin_password = "your-secure-grafana-password-here"
 
 # ============================================================================
+# ACCESS CONTROL
+# ============================================================================
+# IP range allowed to access public services (Grafana, etc.)
+# Set to your home/office network CIDR for security
+# Default: 0.0.0.0/0 (allow all - NOT recommended for production)
+# allowed_ip_range = "192.168.1.0/24"
+
+# ============================================================================
 # OPTIONAL NETWORK CONFIGURATION
 # ============================================================================
 # Override these if you need different network ranges

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,6 +9,18 @@ variable "cloudflare_api_token" {
   }
 }
 
+# Access Control
+variable "allowed_ip_range" {
+  description = "IP range allowed to access public services (CIDR notation). Set to your home/office network for security, or 0.0.0.0/0 to allow all."
+  type        = string
+  default     = "0.0.0.0/0"
+
+  validation {
+    condition     = can(cidrhost(var.allowed_ip_range, 0))
+    error_message = "Must be valid CIDR notation (e.g., 192.168.1.0/24 or 0.0.0.0/0)"
+  }
+}
+
 # Grafana Configuration
 variable "grafana_admin_password" {
   description = "Grafana admin password (should be strong and unique)"


### PR DESCRIPTION
## Summary
- Add root-level `allowed_ip_range` variable to control which IP ranges can access public services
- Previously hardcoded to `192.168.68.0/22` which wouldn't match most users' networks
- Default changed to `0.0.0.0/0` (allow all) for easier initial setup

## Changes
- Add `allowed_ip_range` variable in `variables.tf` with CIDR validation
- Update `grafana01` module to use `var.allowed_ip_range` instead of hardcoded value
- Document the variable in `terraform.tfvars.example`

## Usage
```hcl
# In terraform.tfvars - restrict to your network
allowed_ip_range = "192.168.1.0/24"
```

## Test plan
- [x] `tofu validate` passes
- [ ] Deploy with default (0.0.0.0/0) - should allow access from anywhere
- [ ] Deploy with specific CIDR - should restrict access to that range

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)