### PR TITLE
fix: resolve incus-loki module failure with default config values

### DIFF
--- a/terraform/modules/incus-loki/main.tf
+++ b/terraform/modules/incus-loki/main.tf
@@ -1,14 +1,31 @@
 locals {
   # Build the configuration map for Incus server logging
-  # Only include non-empty values to avoid setting unnecessary config
+  #
+  # IMPORTANT: Incus does not persist config values that match their defaults.
+  # If we send default values, Incus accepts them but doesn't return them via
+  # the API, causing Terraform to report "element has vanished" errors.
+  # See: https://github.com/accuser/atlas/issues/135
+  #
+  # Incus defaults:
+  #   - logging.NAME.types = "lifecycle,logging"
+  #   - logging.NAME.target.retry = 3
+
+  # Required config keys (always set)
   base_config = {
     "logging.${var.logging_name}.target.type"    = "loki"
     "logging.${var.logging_name}.target.address" = var.loki_address
-    "logging.${var.logging_name}.types"          = var.log_types
-    "logging.${var.logging_name}.target.retry"   = tostring(var.retry_count)
   }
 
+  # Only include optional config if values differ from Incus defaults
   optional_config = merge(
+    # Only set types if different from default "lifecycle,logging"
+    var.log_types != "lifecycle,logging" ? {
+      "logging.${var.logging_name}.types" = var.log_types
+    } : {},
+    # Only set retry if different from default 3
+    var.retry_count != 3 ? {
+      "logging.${var.logging_name}.target.retry" = tostring(var.retry_count)
+    } : {},
     var.labels != "" ? {
       "logging.${var.logging_name}.target.labels" = var.labels
     } : {},

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -236,7 +236,7 @@ variable "incus_metrics_server_name" {
 }
 
 variable "enable_incus_loki" {
-  description = "Enable native Incus logging to Loki (sends lifecycle and logging events). Currently disabled by default due to Incus provider bug - see issue #135."
+  description = "Enable native Incus logging to Loki (sends lifecycle and logging events)"
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## Summary

- Fix the "element has vanished" error in the incus-loki module by only setting config values that differ from Incus defaults
- Re-enable the module by default (`enable_incus_loki = true`)

## Problem

Incus does not persist config values that match their defaults. When Terraform sets:
- `logging.NAME.types = "lifecycle,logging"` (the default)
- `logging.NAME.target.retry = "3"` (the default)

Incus accepts these values but doesn't return them via the API. When the Terraform provider reads config back to verify the apply, these keys are missing, causing the error:

```
Error: Provider produced inconsistent result after apply
element "logging.loki01.target.retry" has vanished
element "logging.loki01.types" has vanished
```

## Root Cause Analysis

From the Incus metadata API (`/1.0/metadata/configuration`):
```json
"logging.NAME.types": {
  "defaultdesc": "`lifecycle,logging`"
}
"logging.NAME.target.retry": {
  "shortdesc": "number of delivery retries, default 3"
}
```

Testing confirmed that setting **non-default** values causes Incus to persist and return these keys. Only default values are omitted from the API response.

## Solution

Modified the module to only include `types` and `retry` in the config map if they differ from Incus defaults:

```hcl
optional_config = merge(
  var.log_types != "lifecycle,logging" ? {
    "logging.${var.logging_name}.types" = var.log_types
  } : {},
  var.retry_count != 3 ? {
    "logging.${var.logging_name}.target.retry" = tostring(var.retry_count)
  } : {},
  ...
)
```

## Test plan

- [x] `tofu validate` passes
- [x] `tofu apply` succeeds without "element has vanished" errors
- [x] Incus logging config is correctly applied (`incus config show | grep logging`)

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)