### PR TITLE
fix: enable Caddy metrics scraping and remove step-ca from Prometheus

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -209,14 +209,9 @@ module "prometheus01" {
               service: 'caddy'
               instance: 'caddy01'
 
-      # step-ca health monitoring
-      - job_name: 'step-ca'
-        metrics_path: '/health'
-        static_configs:
-          - targets: ['step-ca01.incus:9000']
-            labels:
-              service: 'step-ca'
-              instance: 'step-ca01'
+      # NOTE: step-ca does not expose Prometheus metrics.
+      # The /health endpoint returns JSON, not Prometheus format.
+      # Health monitoring for step-ca should use blackbox exporter or external probes.
 
       # Node Exporter for host metrics
       - job_name: 'node'

--- a/terraform/modules/caddy/templates/Caddyfile.tftpl
+++ b/terraform/modules/caddy/templates/Caddyfile.tftpl
@@ -1,4 +1,7 @@
 {
+	# Expose admin API for Prometheus metrics scraping
+	admin :2019
+
 	# Order rate_limit directive before basic_auth in the handler chain
 	order rate_limit before basic_auth
 

--- a/terraform/modules/grafana/dashboards/atlas-health.json
+++ b/terraform/modules/grafana/dashboards/atlas-health.json
@@ -392,83 +392,6 @@
         "x": 12,
         "y": 1
       },
-      "id": 6,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "up{job=\"step-ca\"}",
-          "legendFormat": "step-ca",
-          "refId": "A"
-        }
-      ],
-      "title": "step-ca",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "DOWN"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "UP"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 15,
-        "y": 1
-      },
       "id": 7,
       "options": {
         "colorMode": "background",
@@ -543,7 +466,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 18,
+        "x": 15,
         "y": 1
       },
       "id": 8,
@@ -720,7 +643,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg_over_time(up{job=~\"prometheus|grafana|loki|caddy|step-ca|node\"}[$__range])",
+          "expr": "avg_over_time(up{job=~\"prometheus|grafana|loki|caddy|node|incus\"}[$__range])",
           "legendFormat": "{{job}}",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

- Expose Caddy admin API on all interfaces (`:2019`) for Prometheus metrics scraping
- Remove step-ca from Prometheus scrape targets since it doesn't expose Prometheus-format metrics
- Update Atlas Infrastructure Health dashboard to remove step-ca panel and adjust layout
- Add `incus` to the uptime calculation query (replacing `step-ca`)

## Background

After the profile composition refactoring (#147), the health dashboard showed:
- Caddy as "down" - the admin API was only listening on localhost
- step-ca as "down" - it only exposes a JSON health endpoint, not Prometheus metrics

## Changes

**Caddy** (`terraform/modules/caddy/templates/Caddyfile.tftpl`):
- Added `admin :2019` directive to expose the admin API on all network interfaces

**Prometheus Config** (`terraform/main.tf`):
- Removed step-ca scrape job (returns JSON, not Prometheus format)
- Added note that blackbox exporter would be needed for step-ca health monitoring

**Dashboard** (`terraform/modules/grafana/dashboards/atlas-health.json`):
- Removed step-ca panel from Service Health Overview
- Adjusted grid positions for Node Exporter and Incus Metrics panels
- Updated uptime query to include `incus` instead of `step-ca`

## Test plan

- [x] Verify all 6 Prometheus targets are healthy (prometheus, grafana, loki, caddy, node, incus)
- [x] Confirm `node_*` and `incus_*` metrics are visible in Grafana metric browser
- [x] Check Atlas Infrastructure Health dashboard shows all services as UP

🤖 Generated with [Claude Code](https://claude.com/claude-code)