### PR TITLE
docs: add README documentation for Terraform modules

### DIFF
--- a/terraform/modules/alertmanager/README.md
+++ b/terraform/modules/alertmanager/README.md
@@ -1,0 +1,178 @@
+# Alertmanager Terraform Module
+
+This module deploys Prometheus Alertmanager on Incus for alert routing, grouping, and notification management.
+
+## Features
+
+- **Alert Routing**: Configurable routes for different alert types
+- **Notification Channels**: Support for Slack, email, webhook, and more
+- **Silencing**: Persistent storage for silence rules
+- **Inhibition Rules**: Suppress alerts based on other active alerts
+- **Optional TLS**: Certificate management via step-ca
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "alertmanager01" {
+  source = "./modules/alertmanager"
+
+  instance_name = "alertmanager01"
+  profile_name  = "alertmanager"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  enable_data_persistence = true
+  data_volume_name        = "alertmanager01-data"
+  data_volume_size        = "1GB"
+
+  # Optional: Custom configuration
+  alertmanager_config = file("${path.module}/alertmanager.yml")
+}
+```
+
+## Configuration
+
+### Default Configuration
+
+If no custom configuration is provided, Alertmanager uses a minimal default:
+
+```yaml
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: 'default'
+
+receivers:
+  - name: 'default'
+    # No notification channels configured
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname']
+```
+
+### Custom Configuration Example
+
+```yaml
+global:
+  resolve_timeout: 5m
+  slack_api_url: 'https://hooks.slack.com/services/xxx'
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: 'slack-notifications'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'slack-critical'
+
+receivers:
+  - name: 'slack-notifications'
+    slack_configs:
+      - channel: '#alerts'
+        send_resolved: true
+
+  - name: 'slack-critical'
+    slack_configs:
+      - channel: '#alerts-critical'
+        send_resolved: true
+```
+
+## Prometheus Integration
+
+Configure Prometheus to send alerts to Alertmanager:
+
+```yaml
+# In prometheus.yml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager01.incus:9093']
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the Alertmanager instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/alertmanager:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"1"` | no |
+| `memory_limit` | Memory limit (e.g., "256MB") | `string` | `"256MB"` | no |
+| `storage_pool` | Storage pool for the data volume | `string` | `"local"` | no |
+| `enable_data_persistence` | Enable persistent storage | `bool` | `false` | no |
+| `data_volume_name` | Name of the storage volume | `string` | `"alertmanager-data"` | no |
+| `data_volume_size` | Size of storage volume (min 100MB) | `string` | `"1GB"` | no |
+| `alertmanager_port` | Port Alertmanager listens on | `string` | `"9093"` | no |
+| `alertmanager_config` | Custom alertmanager.yml content | `string` | `""` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+| `enable_tls` | Enable TLS via step-ca | `bool` | `false` | no |
+| `stepca_url` | step-ca server URL | `string` | `""` | no |
+| `stepca_fingerprint` | step-ca root certificate fingerprint | `string` | `""` | no |
+| `cert_duration` | TLS certificate duration | `string` | `"24h"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `profile_name` | Name of the created profile |
+| `instance_status` | Status of the instance |
+| `storage_volume_name` | Name of the storage volume (if enabled) |
+| `alertmanager_endpoint` | Internal endpoint URL |
+| `tls_enabled` | Whether TLS is enabled |
+
+## Troubleshooting
+
+### Check Alertmanager status
+
+```bash
+incus exec alertmanager01 -- wget -qO- http://localhost:9093/-/healthy
+```
+
+### View active alerts
+
+```bash
+incus exec alertmanager01 -- wget -qO- http://localhost:9093/api/v2/alerts | jq
+```
+
+### Check configuration
+
+```bash
+incus exec alertmanager01 -- cat /etc/alertmanager/alertmanager.yml
+```
+
+### View logs
+
+```bash
+incus exec alertmanager01 -- cat /var/log/alertmanager.log
+```
+
+## Related Modules
+
+- [prometheus](../prometheus/) - Sends alerts to Alertmanager
+- [step-ca](../step-ca/) - Provides TLS certificates
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Alertmanager Documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
+- [Alertmanager Configuration](https://prometheus.io/docs/alerting/latest/configuration/)
+- [Notification Integrations](https://prometheus.io/docs/alerting/latest/notification_examples/)

--- a/terraform/modules/base-infrastructure/README.md
+++ b/terraform/modules/base-infrastructure/README.md
@@ -1,0 +1,308 @@
+# Base Infrastructure Terraform Module
+
+This module provides the foundational infrastructure for all Atlas services, including networks and reusable Incus profiles.
+
+## Features
+
+- **Five Environment Networks**: Development, Testing, Staging, Production, Management
+- **Docker Base Profile**: Root disk and auto-restart configuration
+- **Network Profiles**: Pre-configured eth0 devices for each network
+- **IPv4 and IPv6 Support**: Optional dual-stack networking
+- **NAT Configuration**: Configurable NAT for each network
+- **Profile Composition**: Enables service modules to compose base + service profiles
+
+## Usage
+
+```hcl
+module "base" {
+  source = "./modules/base-infrastructure"
+
+  storage_pool = "local"
+
+  # Network configuration (defaults shown)
+  development_network_ipv4 = "10.10.0.1/24"
+  testing_network_ipv4     = "10.20.0.1/24"
+  staging_network_ipv4     = "10.30.0.1/24"
+  production_network_ipv4  = "10.40.0.1/24"
+  management_network_ipv4  = "10.50.0.1/24"
+}
+
+# Use base profiles in service modules
+module "grafana01" {
+  source = "./modules/grafana"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+  # ...
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Base Infrastructure                       │
+│                                                              │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │                    Networks                           │  │
+│   │                                                       │  │
+│   │   development  ─── 10.10.0.1/24 ─── Dev workloads    │  │
+│   │   testing      ─── 10.20.0.1/24 ─── Test workloads   │  │
+│   │   staging      ─── 10.30.0.1/24 ─── Staging workloads│  │
+│   │   production   ─── 10.40.0.1/24 ─── Prod workloads   │  │
+│   │   management   ─── 10.50.0.1/24 ─── Internal services│  │
+│   │                                                       │  │
+│   └──────────────────────────────────────────────────────┘  │
+│                                                              │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │                    Profiles                           │  │
+│   │                                                       │  │
+│   │   docker-base ──────────────────────────────────────┐│  │
+│   │   │  boot.autorestart = true                        ││  │
+│   │   │  root disk on storage pool                      ││  │
+│   │   └─────────────────────────────────────────────────┘│  │
+│   │                                                       │  │
+│   │   *-network ────────────────────────────────────────┐│  │
+│   │   │  eth0 device attached to network                ││  │
+│   │   │  (one profile per network)                      ││  │
+│   │   └─────────────────────────────────────────────────┘│  │
+│   │                                                       │  │
+│   └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Profile Composition Pattern
+
+Service modules use profile composition to inherit base infrastructure:
+
+```hcl
+# Service module receives base profiles via var.profiles
+profiles = concat(var.profiles, [incus_profile.service.name])
+
+# Results in ordered profiles:
+# 1. "default"                 - Incus default profile
+# 2. "docker-base"             - Root disk + auto-restart
+# 3. "management-network"      - eth0 on management network
+# 4. "grafana" (service-specific) - CPU/memory limits, data volume
+```
+
+**Profile order matters**: Later profiles override earlier ones. Service-specific profiles define resource limits and service devices, while base profiles provide infrastructure.
+
+## Network Layout
+
+| Network | IPv4 CIDR | Purpose |
+|---------|-----------|---------|
+| development | 10.10.0.1/24 | Development workloads |
+| testing | 10.20.0.1/24 | Testing workloads |
+| staging | 10.30.0.1/24 | Staging workloads |
+| production | 10.40.0.1/24 | Production applications |
+| management | 10.50.0.1/24 | Internal services (monitoring, CA, etc.) |
+
+**Management Network Services:**
+- Grafana, Prometheus, Loki (monitoring stack)
+- step-ca (internal CA)
+- Alertmanager
+- Node Exporter
+- Cloudflared (tunnel client)
+
+## IPv6 Configuration
+
+Enable IPv6 (dual-stack) by setting IPv6 addresses:
+
+```hcl
+module "base" {
+  # ...
+  development_network_ipv6 = "fd00:10:10::1/64"
+  testing_network_ipv6     = "fd00:10:20::1/64"
+  staging_network_ipv6     = "fd00:10:30::1/64"
+  production_network_ipv6  = "fd00:10:40::1/64"
+  management_network_ipv6  = "fd00:10:50::1/64"
+}
+```
+
+**Notes:**
+- IPv6 is disabled by default (empty string)
+- Uses ULA (Unique Local Address) prefix `fd00::/8`
+- NAT66 is configurable per network
+
+## Variables
+
+### Storage
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `storage_pool` | Storage pool for root disks | `string` | `"local"` |
+
+### Development Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `development_network_ipv4` | IPv4 address (CIDR) | `string` | `"10.10.0.1/24"` |
+| `development_network_nat` | Enable IPv4 NAT | `bool` | `true` |
+| `development_network_ipv6` | IPv6 address (CIDR) | `string` | `""` |
+| `development_network_ipv6_nat` | Enable IPv6 NAT | `bool` | `true` |
+
+### Testing Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `testing_network_ipv4` | IPv4 address (CIDR) | `string` | `"10.20.0.1/24"` |
+| `testing_network_nat` | Enable IPv4 NAT | `bool` | `true` |
+| `testing_network_ipv6` | IPv6 address (CIDR) | `string` | `""` |
+| `testing_network_ipv6_nat` | Enable IPv6 NAT | `bool` | `true` |
+
+### Staging Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `staging_network_ipv4` | IPv4 address (CIDR) | `string` | `"10.30.0.1/24"` |
+| `staging_network_nat` | Enable IPv4 NAT | `bool` | `true` |
+| `staging_network_ipv6` | IPv6 address (CIDR) | `string` | `""` |
+| `staging_network_ipv6_nat` | Enable IPv6 NAT | `bool` | `true` |
+
+### Production Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `production_network_ipv4` | IPv4 address (CIDR) | `string` | `"10.40.0.1/24"` |
+| `production_network_nat` | Enable IPv4 NAT | `bool` | `true` |
+| `production_network_ipv6` | IPv6 address (CIDR) | `string` | `""` |
+| `production_network_ipv6_nat` | Enable IPv6 NAT | `bool` | `true` |
+
+### Management Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `management_network_ipv4` | IPv4 address (CIDR) | `string` | `"10.50.0.1/24"` |
+| `management_network_nat` | Enable IPv4 NAT | `bool` | `true` |
+| `management_network_ipv6` | IPv6 address (CIDR) | `string` | `""` |
+| `management_network_ipv6_nat` | Enable IPv6 NAT | `bool` | `true` |
+
+### External Network
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `external_network` | External network name | `string` | `"incusbr0"` |
+
+## Outputs
+
+### Networks
+
+| Name | Description |
+|------|-------------|
+| `development_network` | Development network resource |
+| `testing_network` | Testing network resource |
+| `staging_network` | Staging network resource |
+| `production_network` | Production network resource |
+| `management_network` | Management network resource |
+| `management_network_gateway` | Management network gateway IP (for Incus metrics) |
+| `external_network` | External network name |
+
+### Profiles
+
+| Name | Description |
+|------|-------------|
+| `docker_base_profile` | Docker base profile (boot.autorestart, root disk) |
+| `development_network_profile` | Development network profile (eth0) |
+| `testing_network_profile` | Testing network profile (eth0) |
+| `staging_network_profile` | Staging network profile (eth0) |
+| `production_network_profile` | Production network profile (eth0) |
+| `management_network_profile` | Management network profile (eth0) |
+
+## Troubleshooting
+
+### List networks
+
+```bash
+incus network list
+```
+
+### View network configuration
+
+```bash
+incus network show management
+```
+
+### List profiles
+
+```bash
+incus profile list
+```
+
+### View profile configuration
+
+```bash
+incus profile show docker-base
+incus profile show management-network
+```
+
+### Check container network
+
+```bash
+incus exec grafana01 -- ip addr
+incus exec grafana01 -- ping prometheus01.incus
+```
+
+### Test cross-network connectivity
+
+```bash
+# From management network container
+incus exec grafana01 -- ping caddy01.incus  # Should work if Caddy is on management
+```
+
+## Service Module Integration
+
+Service modules should accept a `profiles` variable:
+
+```hcl
+# In service module's variables.tf
+variable "profiles" {
+  description = "List of Incus profile names to apply (should include base profiles)"
+  type        = list(string)
+  default     = ["default"]
+}
+
+# In service module's main.tf
+resource "incus_instance" "service" {
+  # ...
+  profiles = concat(var.profiles, [incus_profile.service.name])
+}
+```
+
+This pattern allows the root module to compose infrastructure:
+
+```hcl
+# In root main.tf
+module "grafana01" {
+  source = "./modules/grafana"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+}
+```
+
+## Related Modules
+
+All service modules depend on base-infrastructure:
+
+- [alertmanager](../alertmanager/)
+- [caddy](../caddy/)
+- [cloudflared](../cloudflared/)
+- [grafana](../grafana/)
+- [loki](../loki/)
+- [mosquitto](../mosquitto/)
+- [node-exporter](../node-exporter/)
+- [prometheus](../prometheus/)
+- [step-ca](../step-ca/)
+
+## References
+
+- [Incus Networks](https://linuxcontainers.org/incus/docs/main/networks/)
+- [Incus Profiles](https://linuxcontainers.org/incus/docs/main/profiles/)
+- [Profile Composition](https://linuxcontainers.org/incus/docs/main/profiles/#profile-stacking)

--- a/terraform/modules/cloudflared/README.md
+++ b/terraform/modules/cloudflared/README.md
@@ -1,0 +1,179 @@
+# Cloudflared Terraform Module
+
+This module deploys the Cloudflare Tunnel client (cloudflared) on Incus for secure Zero Trust access to internal services.
+
+## Features
+
+- **Zero Trust Access**: Secure remote access without exposing ports
+- **Token-Based Auth**: Managed via Cloudflare dashboard
+- **Metrics Endpoint**: Prometheus-compatible metrics for monitoring
+- **Lightweight**: Minimal resource requirements
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "cloudflared01" {
+  source = "./modules/cloudflared"
+
+  count = var.cloudflared_tunnel_token != "" ? 1 : 0
+
+  instance_name = "cloudflared01"
+  profile_name  = "cloudflared"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  tunnel_token = var.cloudflared_tunnel_token
+}
+```
+
+## Prerequisites
+
+### Create a Cloudflare Tunnel
+
+1. Log in to [Cloudflare Zero Trust Dashboard](https://one.dash.cloudflare.com/)
+2. Navigate to **Access** > **Tunnels**
+3. Click **Create a tunnel**
+4. Choose **Cloudflared** as the connector
+5. Name your tunnel (e.g., "atlas-tunnel")
+6. Copy the tunnel token
+
+### Configure Public Hostnames
+
+In the Cloudflare dashboard, configure routes for your services:
+
+| Public Hostname | Service | URL |
+|-----------------|---------|-----|
+| grafana.example.com | HTTP | http://grafana01.incus:3000 |
+| prometheus.example.com | HTTP | http://prometheus01.incus:9090 |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Internet                                 │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Cloudflare Edge                            │
+│  (DDoS protection, WAF, Access policies)                    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ Encrypted tunnel
+                            │ (outbound only)
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    cloudflared                               │
+│              (management network)                            │
+└─────────────────────────────────────────────────────────────┘
+                            │
+            ┌───────────────┼───────────────┐
+            ▼               ▼               ▼
+      ┌──────────┐   ┌──────────┐   ┌──────────┐
+      │ Grafana  │   │Prometheus│   │   Loki   │
+      └──────────┘   └──────────┘   └──────────┘
+```
+
+## Security Benefits
+
+1. **No Inbound Ports**: All connections are outbound from cloudflared
+2. **Cloudflare Access**: Add identity-based access controls
+3. **DDoS Protection**: Traffic filtered at Cloudflare edge
+4. **WAF Rules**: Apply Web Application Firewall rules
+5. **Audit Logs**: Full visibility into access attempts
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the cloudflared instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `tunnel_token` | Cloudflare Tunnel token (sensitive) | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/cloudflared:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"1"` | no |
+| `memory_limit` | Memory limit (e.g., "256MB") | `string` | `"256MB"` | no |
+| `metrics_port` | Port for metrics endpoint | `string` | `"2000"` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `profile_name` | Name of the created profile |
+| `instance_status` | Status of the instance |
+| `metrics_endpoint` | Prometheus metrics endpoint URL |
+
+## Conditional Deployment
+
+The module is typically deployed conditionally based on token availability:
+
+```hcl
+# In terraform.tfvars
+cloudflared_tunnel_token = "eyJhIjoiYWJjMTIz..."  # Set to enable
+
+# In main.tf
+module "cloudflared01" {
+  source = "./modules/cloudflared"
+  count  = var.cloudflared_tunnel_token != "" ? 1 : 0
+  # ...
+}
+```
+
+## Troubleshooting
+
+### Check tunnel status
+
+```bash
+incus exec cloudflared01 -- cloudflared tunnel info
+```
+
+### View connection logs
+
+```bash
+incus exec cloudflared01 -- cat /var/log/cloudflared.log
+```
+
+### Test metrics endpoint
+
+```bash
+curl http://cloudflared01.incus:2000/metrics
+```
+
+### Verify tunnel connectivity
+
+```bash
+# Check if tunnel is connected
+incus exec cloudflared01 -- cloudflared tunnel list
+```
+
+## Prometheus Integration
+
+Add cloudflared to Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'cloudflared'
+    static_configs:
+      - targets: ['cloudflared01.incus:2000']
+        labels:
+          service: 'cloudflared'
+          instance: 'cloudflared01'
+```
+
+## Related Modules
+
+- [caddy](../caddy/) - Alternative for public HTTPS with Let's Encrypt
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Cloudflare Tunnel Documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+- [Zero Trust Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+- [Cloudflared Metrics](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/monitor-tunnels/metrics/)

--- a/terraform/modules/loki/README.md
+++ b/terraform/modules/loki/README.md
@@ -1,0 +1,197 @@
+# Loki Terraform Module
+
+This module deploys Grafana Loki on Incus for log aggregation and querying.
+
+## Features
+
+- **Log Aggregation**: Collects and indexes logs from all services
+- **LogQL**: Powerful query language for log exploration
+- **Retention Management**: Configurable log retention policies
+- **Persistent Storage**: Optional persistent volume for log data
+- **Optional TLS**: Certificate management via step-ca
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "loki01" {
+  source = "./modules/loki"
+
+  instance_name = "loki01"
+  profile_name  = "loki"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  enable_data_persistence = true
+  data_volume_name        = "loki01-data"
+  data_volume_size        = "50GB"
+
+  # Retention settings
+  retention_period       = "720h"  # 30 days
+  retention_delete_delay = "2h"
+}
+```
+
+## Retention Configuration
+
+Loki supports time-based retention to automatically delete old logs:
+
+| Duration | Hours | Use Case |
+|----------|-------|----------|
+| 7 days | `168h` | Development/testing |
+| 14 days | `336h` | Short-term retention |
+| 30 days | `720h` | Standard retention (default) |
+| 90 days | `2160h` | Extended retention |
+
+```hcl
+module "loki01" {
+  # ...
+  retention_period       = "720h"  # Keep logs for 30 days
+  retention_delete_delay = "2h"    # Wait 2h before deleting
+}
+```
+
+## Grafana Integration
+
+Configure Loki as a datasource in Grafana:
+
+```hcl
+module "grafana01" {
+  # ...
+  datasources = [
+    {
+      name       = "Loki"
+      type       = "loki"
+      url        = module.loki01.loki_endpoint
+      is_default = false
+    }
+  ]
+}
+```
+
+## Incus Native Logging
+
+Loki can receive logs directly from Incus using the incus-loki module:
+
+```hcl
+module "incus_loki" {
+  source = "./modules/incus-loki"
+
+  logging_name   = "loki01"
+  loki_address   = module.loki01.loki_endpoint_ip
+  instance_types = "container,virtual-machine"
+  event_types    = "lifecycle,logging"
+}
+```
+
+This enables:
+- **Lifecycle events**: Instance start/stop, create, delete
+- **Logging events**: Container and VM log output
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the Loki instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/loki:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"2"` | no |
+| `memory_limit` | Memory limit (e.g., "2GB") | `string` | `"2GB"` | no |
+| `storage_pool` | Storage pool for the data volume | `string` | `"local"` | no |
+| `enable_data_persistence` | Enable persistent storage | `bool` | `false` | no |
+| `data_volume_name` | Name of the storage volume | `string` | `"loki-data"` | no |
+| `data_volume_size` | Size of storage volume (min 10GB) | `string` | `"50GB"` | no |
+| `loki_port` | Port Loki listens on | `string` | `"3100"` | no |
+| `retention_period` | Log retention period (e.g., "720h") | `string` | `"720h"` | no |
+| `retention_delete_delay` | Delay before deletion (min 2h) | `string` | `"2h"` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+| `enable_tls` | Enable TLS via step-ca | `bool` | `false` | no |
+| `stepca_url` | step-ca server URL | `string` | `""` | no |
+| `stepca_fingerprint` | step-ca root certificate fingerprint | `string` | `""` | no |
+| `cert_duration` | TLS certificate duration | `string` | `"24h"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `profile_name` | Name of the created profile |
+| `instance_status` | Status of the instance |
+| `storage_volume_name` | Name of the storage volume (if enabled) |
+| `loki_endpoint` | Internal endpoint URL (using .incus DNS) |
+| `loki_endpoint_ip` | Endpoint URL using IP address |
+| `ipv4_address` | IPv4 address of the instance |
+| `tls_enabled` | Whether TLS is enabled |
+
+## Troubleshooting
+
+### Check Loki status
+
+```bash
+incus exec loki01 -- wget -qO- http://localhost:3100/ready
+```
+
+### View Loki metrics
+
+```bash
+incus exec loki01 -- wget -qO- http://localhost:3100/metrics | head -50
+```
+
+### Query logs via API
+
+```bash
+# Query last 10 log entries
+incus exec loki01 -- wget -qO- 'http://localhost:3100/loki/api/v1/query_range?query={job="varlogs"}&limit=10'
+```
+
+### Check storage usage
+
+```bash
+incus exec loki01 -- du -sh /loki
+```
+
+### View configuration
+
+```bash
+incus exec loki01 -- cat /etc/loki/local-config.yaml
+```
+
+## LogQL Examples
+
+Query logs in Grafana using LogQL:
+
+```logql
+# All logs from a specific job
+{job="grafana"}
+
+# Filter by log level
+{job="grafana"} |= "error"
+
+# Regex matching
+{job="grafana"} |~ "user.*login"
+
+# JSON parsing
+{job="api"} | json | status >= 400
+
+# Rate of errors
+rate({job="api"} |= "error" [5m])
+```
+
+## Related Modules
+
+- [grafana](../grafana/) - Visualizes Loki logs
+- [incus-loki](../incus-loki/) - Configures Incus to send logs to Loki
+- [step-ca](../step-ca/) - Provides TLS certificates
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Loki Documentation](https://grafana.com/docs/loki/latest/)
+- [LogQL Documentation](https://grafana.com/docs/loki/latest/logql/)
+- [Loki Configuration](https://grafana.com/docs/loki/latest/configure/)
+- [Retention Configuration](https://grafana.com/docs/loki/latest/operations/storage/retention/)

--- a/terraform/modules/mosquitto/README.md
+++ b/terraform/modules/mosquitto/README.md
@@ -1,0 +1,215 @@
+# Mosquitto Terraform Module
+
+This module deploys Eclipse Mosquitto MQTT broker on Incus for IoT messaging and pub/sub communication.
+
+## Features
+
+- **MQTT Protocol**: Lightweight publish/subscribe messaging
+- **External Access**: Host port forwarding via Incus proxy devices
+- **Authentication**: Password-based user authentication
+- **Persistent Storage**: Optional persistent volume for retained messages
+- **Optional TLS**: Certificate management via step-ca
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "mosquitto01" {
+  source = "./modules/mosquitto"
+
+  instance_name = "mosquitto01"
+  profile_name  = "mosquitto"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.production_network_profile.name,
+  ]
+
+  enable_data_persistence = true
+  data_volume_name        = "mosquitto01-data"
+  data_volume_size        = "5GB"
+
+  enable_external_access = true
+  external_mqtt_port     = "1883"
+
+  # Optional: User authentication
+  mqtt_users = {
+    "sensor1" = "secret123"
+    "app1"    = "anothersecret"
+  }
+}
+```
+
+## External Access
+
+Mosquitto uses **Incus proxy devices** instead of Caddy reverse proxy for external access. This is because MQTT is a TCP protocol, not HTTP.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Host                                    │
+│                                                              │
+│   Port 1883 ──────────────────┐                             │
+│   (external)                   │                             │
+│                                ▼                             │
+│   ┌─────────────────────────────────────────────┐           │
+│   │              Mosquitto Container             │           │
+│   │                                              │           │
+│   │   mqtt-proxy: tcp:0.0.0.0:1883              │           │
+│   │        └───► tcp:127.0.0.1:1883             │           │
+│   │                                              │           │
+│   │   (mqtts-proxy when TLS enabled)            │           │
+│   └─────────────────────────────────────────────┘           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Authentication
+
+### Password-Based Authentication
+
+Configure users via the `mqtt_users` variable:
+
+```hcl
+module "mosquitto01" {
+  # ...
+  mqtt_users = {
+    "device1"  = var.mqtt_device1_password
+    "backend"  = var.mqtt_backend_password
+  }
+}
+```
+
+**Security Note**: Store passwords in `terraform.tfvars` (gitignored) or environment variables:
+
+```hcl
+# terraform.tfvars
+mqtt_device1_password = "secure-password-here"
+```
+
+### Anonymous Access
+
+If `mqtt_users` is empty, anonymous access is allowed (not recommended for production).
+
+## TLS Configuration
+
+Enable encrypted MQTT (MQTTS) using step-ca certificates:
+
+```hcl
+module "mosquitto01" {
+  # ...
+  enable_tls         = true
+  stepca_url         = module.step_ca01.acme_endpoint
+  stepca_fingerprint = var.stepca_fingerprint
+
+  enable_external_access = true
+  external_mqtt_port     = "1883"   # Plain MQTT
+  external_mqtts_port    = "8883"   # MQTT over TLS
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the Mosquitto instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/mosquitto:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"1"` | no |
+| `memory_limit` | Memory limit (e.g., "256MB") | `string` | `"256MB"` | no |
+| `storage_pool` | Storage pool for the data volume | `string` | `"local"` | no |
+| `enable_data_persistence` | Enable persistent storage | `bool` | `false` | no |
+| `data_volume_name` | Name of the storage volume | `string` | `"mosquitto-data"` | no |
+| `data_volume_size` | Size of storage volume (min 100MB) | `string` | `"5GB"` | no |
+| `mqtt_port` | Internal MQTT port | `string` | `"1883"` | no |
+| `mqtts_port` | Internal MQTTS port | `string` | `"8883"` | no |
+| `enable_external_access` | Enable external access via proxy | `bool` | `true` | no |
+| `external_mqtt_port` | Host port for external MQTT | `string` | `"1883"` | no |
+| `external_mqtts_port` | Host port for external MQTTS | `string` | `"8883"` | no |
+| `mqtt_users` | Map of username to password | `map(string)` | `{}` | no |
+| `mosquitto_config` | Custom configuration to append | `string` | `""` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+| `enable_tls` | Enable TLS via step-ca | `bool` | `false` | no |
+| `stepca_url` | step-ca server URL | `string` | `""` | no |
+| `stepca_fingerprint` | step-ca root certificate fingerprint | `string` | `""` | no |
+| `cert_duration` | TLS certificate duration | `string` | `"24h"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `mqtt_endpoint` | Internal MQTT endpoint URL |
+| `mqtts_endpoint` | Internal MQTTS endpoint (if TLS enabled) |
+| `external_mqtt_port` | Host port for external MQTT |
+| `external_mqtts_port` | Host port for external MQTTS |
+| `tls_enabled` | Whether TLS is enabled |
+| `external_access_enabled` | Whether external access is enabled |
+
+## Troubleshooting
+
+### Test MQTT connection
+
+```bash
+# From the host (requires mosquitto-clients)
+mosquitto_pub -h localhost -p 1883 -t "test/topic" -m "Hello"
+mosquitto_sub -h localhost -p 1883 -t "test/topic"
+
+# With authentication
+mosquitto_pub -h localhost -p 1883 -u "device1" -P "password" -t "test/topic" -m "Hello"
+```
+
+### Check Mosquitto status
+
+```bash
+incus exec mosquitto01 -- cat /mosquitto/log/mosquitto.log
+```
+
+### View active connections
+
+```bash
+incus exec mosquitto01 -- mosquitto_ctrl -h localhost -u admin list clients
+```
+
+### Verify configuration
+
+```bash
+incus exec mosquitto01 -- cat /mosquitto/config/mosquitto.conf
+```
+
+### Test from within container
+
+```bash
+incus exec mosquitto01 -- mosquitto_pub -h localhost -t "test" -m "hello"
+```
+
+## Custom Configuration
+
+Add custom Mosquitto configuration:
+
+```hcl
+module "mosquitto01" {
+  # ...
+  mosquitto_config = <<-EOT
+    # Custom settings
+    max_connections 1000
+    max_inflight_messages 20
+    max_queued_messages 1000
+
+    # Logging
+    log_type all
+    log_dest file /mosquitto/log/mosquitto.log
+  EOT
+}
+```
+
+## Related Modules
+
+- [step-ca](../step-ca/) - Provides TLS certificates
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Eclipse Mosquitto](https://mosquitto.org/)
+- [Mosquitto Configuration](https://mosquitto.org/man/mosquitto-conf-5.html)
+- [MQTT Protocol](https://mqtt.org/)

--- a/terraform/modules/node-exporter/README.md
+++ b/terraform/modules/node-exporter/README.md
@@ -1,0 +1,200 @@
+# Node Exporter Terraform Module
+
+This module deploys Prometheus Node Exporter on Incus for host-level metrics collection.
+
+## Features
+
+- **Host Metrics**: CPU, memory, disk, network, and filesystem metrics
+- **Read-Only Mounts**: Secure access to host filesystem via read-only mounts
+- **Lightweight**: Minimal resource footprint
+- **Prometheus Compatible**: Standard `/metrics` endpoint
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "node_exporter01" {
+  source = "./modules/node-exporter"
+
+  instance_name = "node-exporter01"
+  profile_name  = "node-exporter"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+}
+```
+
+## Architecture
+
+Node Exporter collects metrics from the host system via read-only filesystem mounts:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Host System                             │
+│                                                              │
+│   /           ──────────────────────────────────────┐       │
+│   /proc       ──────────────────────────────┐       │       │
+│   /sys        ────────────────────┐         │       │       │
+│                                    │         │       │       │
+│   ┌────────────────────────────────┴─────────┴───────┴──┐   │
+│   │              Node Exporter Container                 │   │
+│   │                                                      │   │
+│   │   /host      (read-only mount of /)                 │   │
+│   │   /host/proc (read-only mount of /proc)             │   │
+│   │   /host/sys  (read-only mount of /sys)              │   │
+│   │                                                      │   │
+│   │   :9100/metrics ───► Prometheus                     │   │
+│   └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Metrics Collected
+
+Node Exporter provides hundreds of metrics. Key categories include:
+
+| Category | Example Metrics |
+|----------|-----------------|
+| CPU | `node_cpu_seconds_total`, `node_load1` |
+| Memory | `node_memory_MemTotal_bytes`, `node_memory_MemAvailable_bytes` |
+| Disk | `node_disk_io_time_seconds_total`, `node_disk_read_bytes_total` |
+| Filesystem | `node_filesystem_avail_bytes`, `node_filesystem_size_bytes` |
+| Network | `node_network_receive_bytes_total`, `node_network_transmit_bytes_total` |
+| System | `node_boot_time_seconds`, `node_time_seconds` |
+
+## Prometheus Integration
+
+Add Node Exporter to Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter01.incus:9100']
+        labels:
+          service: 'node-exporter'
+          instance: 'node-exporter01'
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the Node Exporter instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/node-exporter:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"1"` | no |
+| `memory_limit` | Memory limit (e.g., "256MB") | `string` | `"256MB"` | no |
+| `node_exporter_port` | Port Node Exporter listens on | `string` | `"9100"` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `profile_name` | Name of the created profile |
+| `node_exporter_endpoint` | Metrics endpoint URL |
+
+## Security
+
+Node Exporter uses **read-only mounts** for security:
+
+```hcl
+device {
+  name = "host-root"
+  type = "disk"
+  properties = {
+    source   = "/"
+    path     = "/host"
+    readonly = "true"  # Cannot modify host filesystem
+  }
+}
+```
+
+The container also runs unprivileged:
+
+```hcl
+config = {
+  "security.privileged" = "false"
+}
+```
+
+## Troubleshooting
+
+### Test metrics endpoint
+
+```bash
+curl http://node-exporter01.incus:9100/metrics | head -50
+```
+
+### Check specific metrics
+
+```bash
+# CPU usage
+curl -s http://node-exporter01.incus:9100/metrics | grep node_cpu_seconds_total
+
+# Memory usage
+curl -s http://node-exporter01.incus:9100/metrics | grep node_memory_MemAvailable_bytes
+
+# Disk space
+curl -s http://node-exporter01.incus:9100/metrics | grep node_filesystem_avail_bytes
+```
+
+### Verify mounts inside container
+
+```bash
+incus exec node-exporter01 -- ls -la /host
+incus exec node-exporter01 -- cat /host/proc/meminfo | head -10
+```
+
+### Check container status
+
+```bash
+incus exec node-exporter01 -- wget -qO- http://localhost:9100/metrics | wc -l
+```
+
+## Grafana Dashboards
+
+Popular Node Exporter dashboards for Grafana:
+
+- **Node Exporter Full**: Dashboard ID 1860
+- **Node Exporter for Prometheus**: Dashboard ID 11074
+- **Host Stats**: Dashboard ID 6287
+
+Import via Grafana UI: Dashboards → Import → Enter dashboard ID
+
+## Common PromQL Queries
+
+```promql
+# CPU usage percentage
+100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+
+# Memory usage percentage
+(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100
+
+# Disk usage percentage
+(1 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})) * 100
+
+# Network traffic (bytes/sec)
+rate(node_network_receive_bytes_total[5m])
+rate(node_network_transmit_bytes_total[5m])
+
+# System uptime
+node_time_seconds - node_boot_time_seconds
+```
+
+## Related Modules
+
+- [prometheus](../prometheus/) - Scrapes Node Exporter metrics
+- [grafana](../grafana/) - Visualizes metrics
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Node Exporter Documentation](https://prometheus.io/docs/guides/node-exporter/)
+- [Node Exporter GitHub](https://github.com/prometheus/node_exporter)
+- [Available Collectors](https://github.com/prometheus/node_exporter#collectors)

--- a/terraform/modules/prometheus/README.md
+++ b/terraform/modules/prometheus/README.md
@@ -1,0 +1,338 @@
+# Prometheus Terraform Module
+
+This module deploys Prometheus metrics collection and time-series database on Incus for infrastructure monitoring.
+
+## Features
+
+- **Time-Series Database**: Efficient storage for metrics data
+- **Flexible Scraping**: Configurable scrape targets via prometheus.yml
+- **Alert Rules**: Support for custom alerting rules
+- **Incus Metrics**: mTLS authentication for scraping Incus container metrics
+- **Retention Policies**: Time-based and size-based retention
+- **Optional TLS**: Certificate management via step-ca
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "prometheus01" {
+  source = "./modules/prometheus"
+
+  instance_name = "prometheus01"
+  profile_name  = "prometheus"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  enable_data_persistence = true
+  data_volume_name        = "prometheus01-data"
+  data_volume_size        = "100GB"
+
+  retention_time = "30d"
+  retention_size = "90GB"
+
+  prometheus_config = file("prometheus.yml")
+  alert_rules       = file("alerts.yml")
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Prometheus Container                      │
+│                                                              │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │                  Prometheus Server                    │  │
+│   │                                                       │  │
+│   │   /etc/prometheus/prometheus.yml  (scrape config)    │  │
+│   │   /etc/prometheus/alerts/         (alert rules)      │  │
+│   │   /prometheus                     (data storage)     │  │
+│   │                                                       │  │
+│   │   :9090/graph    ───► Query UI                       │  │
+│   │   :9090/api      ───► HTTP API                       │  │
+│   │   :9090/metrics  ───► Self-monitoring                │  │
+│   └──────────────────────────────────────────────────────┘  │
+│                              │                               │
+│                              ▼                               │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │              Scrape Targets                           │  │
+│   │   • grafana01.incus:3000/metrics                     │  │
+│   │   • loki01.incus:3100/metrics                        │  │
+│   │   • node-exporter01.incus:9100/metrics               │  │
+│   │   • <incus-api>:8443/1.0/metrics (mTLS)              │  │
+│   └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Configuration
+
+### Prometheus Configuration File
+
+Inject a custom `prometheus.yml` configuration:
+
+```hcl
+module "prometheus01" {
+  # ...
+  prometheus_config = <<-EOT
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: 'grafana'
+        static_configs:
+          - targets: ['grafana01.incus:3000']
+            labels:
+              service: 'grafana'
+
+      - job_name: 'node'
+        static_configs:
+          - targets: ['node-exporter01.incus:9100']
+            labels:
+              service: 'node-exporter'
+  EOT
+}
+```
+
+### Alert Rules
+
+Add custom alerting rules:
+
+```hcl
+module "prometheus01" {
+  # ...
+  alert_rules = <<-EOT
+    groups:
+      - name: service-availability
+        rules:
+          - alert: ServiceDown
+            expr: up == 0
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Service {{ $labels.job }} is down"
+              description: "{{ $labels.instance }} has been unreachable for 2 minutes."
+
+          - alert: HighMemoryUsage
+            expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.9
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "High memory usage detected"
+              description: "Memory usage is above 90% for 5 minutes."
+  EOT
+}
+```
+
+### Incus Metrics (mTLS)
+
+Scrape container metrics from the Incus API:
+
+```hcl
+module "incus_metrics" {
+  source = "./modules/incus-metrics"
+  # ... generates certificate and key
+}
+
+module "prometheus01" {
+  # ...
+  incus_metrics_certificate = module.incus_metrics.certificate_pem
+  incus_metrics_private_key = module.incus_metrics.private_key_pem
+
+  prometheus_config = <<-EOT
+    scrape_configs:
+      - job_name: 'incus'
+        scheme: https
+        tls_config:
+          cert_file: /etc/prometheus/tls/metrics.crt
+          key_file: /etc/prometheus/tls/metrics.key
+          insecure_skip_verify: true
+        static_configs:
+          - targets: ['10.50.0.1:8443']
+        metrics_path: /1.0/metrics
+  EOT
+}
+```
+
+## Retention Configuration
+
+Prometheus supports both time-based and size-based retention:
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `retention_time` | How long to keep data | `30d` | `15d`, `90d`, `1y` |
+| `retention_size` | Max storage size | `""` (disabled) | `50GB`, `90GB` |
+
+When both are set, whichever limit is reached first triggers deletion:
+
+```hcl
+module "prometheus01" {
+  # ...
+  retention_time = "30d"    # Keep data for 30 days
+  retention_size = "90GB"   # OR delete when storage exceeds 90GB
+}
+```
+
+**Common retention configurations:**
+
+| Use Case | Time | Size |
+|----------|------|------|
+| Development | `7d` | `10GB` |
+| Production | `30d` | `90GB` |
+| Long-term | `90d` | `500GB` |
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the Prometheus instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/prometheus:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"2"` | no |
+| `memory_limit` | Memory limit (e.g., "2GB") | `string` | `"2GB"` | no |
+| `storage_pool` | Storage pool for the data volume | `string` | `"local"` | no |
+| `enable_data_persistence` | Enable persistent storage | `bool` | `false` | no |
+| `data_volume_name` | Name of the storage volume | `string` | `"prometheus-data"` | no |
+| `data_volume_size` | Size of storage volume (min 10GB) | `string` | `"100GB"` | no |
+| `prometheus_port` | Port Prometheus listens on | `string` | `"9090"` | no |
+| `prometheus_config` | Prometheus configuration (prometheus.yml) | `string` | `""` | no |
+| `alert_rules` | Alert rules file content (alerts.yml) | `string` | `""` | no |
+| `retention_time` | How long to retain metrics (e.g., "30d") | `string` | `"30d"` | no |
+| `retention_size` | Max storage size before deletion | `string` | `""` | no |
+| `environment_variables` | Additional environment variables | `map(string)` | `{}` | no |
+| `enable_tls` | Enable TLS via step-ca | `bool` | `false` | no |
+| `stepca_url` | step-ca server URL | `string` | `""` | no |
+| `stepca_fingerprint` | step-ca root certificate fingerprint | `string` | `""` | no |
+| `cert_duration` | TLS certificate duration | `string` | `"24h"` | no |
+| `incus_metrics_certificate` | Certificate for Incus metrics scraping | `string` | `""` | no |
+| `incus_metrics_private_key` | Private key for Incus metrics scraping | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `profile_name` | Name of the created profile |
+| `instance_status` | Status of the instance |
+| `storage_volume_name` | Name of the storage volume (if enabled) |
+| `prometheus_endpoint` | Prometheus endpoint URL |
+| `tls_enabled` | Whether TLS is enabled |
+
+## Troubleshooting
+
+### Check Prometheus status
+
+```bash
+incus exec prometheus01 -- wget -qO- http://localhost:9090/-/ready
+```
+
+### View scrape targets
+
+```bash
+# List all targets and their status
+curl -s http://prometheus01.incus:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, instance: .labels.instance, health: .health}'
+```
+
+### Check configuration
+
+```bash
+incus exec prometheus01 -- cat /etc/prometheus/prometheus.yml
+```
+
+### Query metrics
+
+```bash
+# Instant query
+curl -s 'http://prometheus01.incus:9090/api/v1/query?query=up' | jq
+
+# Range query (last hour)
+curl -s 'http://prometheus01.incus:9090/api/v1/query_range?query=up&start='$(date -d '1 hour ago' +%s)'&end='$(date +%s)'&step=60' | jq
+```
+
+### Check storage usage
+
+```bash
+# Current storage size
+curl -s http://prometheus01.incus:9090/api/v1/status/tsdb | jq '.data.headStats'
+```
+
+### View active alerts
+
+```bash
+curl -s http://prometheus01.incus:9090/api/v1/alerts | jq '.data.alerts'
+```
+
+### Reload configuration
+
+```bash
+# Send SIGHUP to Prometheus
+incus exec prometheus01 -- pkill -HUP prometheus
+```
+
+## Grafana Integration
+
+Add Prometheus as a data source in Grafana:
+
+```hcl
+module "grafana01" {
+  # ...
+  datasources = [
+    {
+      name       = "Prometheus"
+      type       = "prometheus"
+      url        = module.prometheus01.prometheus_endpoint
+      is_default = true
+    }
+  ]
+}
+```
+
+## Common PromQL Queries
+
+```promql
+# CPU usage across all containers
+sum(rate(incus_cpu_seconds_total[5m])) by (name)
+
+# Memory usage percentage
+(incus_memory_MemTotal_bytes - incus_memory_MemAvailable_bytes) / incus_memory_MemTotal_bytes * 100
+
+# Network traffic (bytes/sec)
+rate(incus_network_receive_bytes_total[5m])
+rate(incus_network_transmit_bytes_total[5m])
+
+# Service uptime
+up{job="grafana"}
+
+# Request rate (if using a service with metrics)
+rate(http_requests_total[5m])
+
+# Alert firing count
+ALERTS{alertstate="firing"}
+```
+
+## Related Modules
+
+- [alertmanager](../alertmanager/) - Routes alerts from Prometheus
+- [grafana](../grafana/) - Visualizes Prometheus metrics
+- [loki](../loki/) - Log aggregation (complements metrics)
+- [node-exporter](../node-exporter/) - Host-level metrics
+- [incus-metrics](../incus-metrics/) - Incus container metrics
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [PromQL Basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)
+- [Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+- [Storage](https://prometheus.io/docs/prometheus/latest/storage/)

--- a/terraform/modules/step-ca/README.md
+++ b/terraform/modules/step-ca/README.md
@@ -1,0 +1,248 @@
+# step-ca Terraform Module
+
+This module deploys step-ca, an internal ACME Certificate Authority, on Incus for automated TLS certificate management.
+
+## Features
+
+- **Internal PKI**: Private Certificate Authority for your infrastructure
+- **ACME Protocol**: Automated certificate issuance and renewal
+- **Short-Lived Certificates**: Default 24-hour certificates for security
+- **Persistent Storage**: Secure storage for CA keys and configuration
+- **DNS Name Support**: Configurable DNS names for the CA certificate
+- **Profile Composition**: Works with base-infrastructure module profiles
+
+## Usage
+
+```hcl
+module "step_ca01" {
+  source = "./modules/step-ca"
+
+  instance_name = "step-ca01"
+  profile_name  = "step-ca"
+
+  profiles = [
+    "default",
+    module.base.docker_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  ca_name = "Atlas Internal CA"
+
+  enable_data_persistence = true
+  data_volume_name        = "step-ca01-data"
+  data_volume_size        = "1GB"
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    step-ca Container                         │
+│                                                              │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │                  step-ca Server                       │  │
+│   │                                                       │  │
+│   │   /home/step/certs/root_ca.crt  (Root CA cert)       │  │
+│   │   /home/step/secrets/           (Private keys)       │  │
+│   │   /home/step/config/            (CA configuration)   │  │
+│   │   /home/step/fingerprint        (CA fingerprint)     │  │
+│   │                                                       │  │
+│   │   :9000/acme/acme/directory ───► ACME Endpoint       │  │
+│   │   :9000/health              ───► Health Check        │  │
+│   └──────────────────────────────────────────────────────┘  │
+│                              │                               │
+│                              ▼                               │
+│   ┌──────────────────────────────────────────────────────┐  │
+│   │              ACME Clients                             │  │
+│   │   • Grafana (enable_tls = true)                      │  │
+│   │   • Prometheus (enable_tls = true)                   │  │
+│   │   • Loki (enable_tls = true)                         │  │
+│   │   • Mosquitto (enable_tls = true)                    │  │
+│   └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Two-Phase Deployment
+
+Since the CA fingerprint is generated at runtime, TLS configuration requires a two-phase deployment:
+
+### Phase 1: Deploy step-ca
+
+```bash
+# Deploy infrastructure (step-ca generates fingerprint)
+make deploy
+
+# Retrieve the CA fingerprint
+incus exec step-ca01 -- cat /home/step/fingerprint
+# Example output: abc123def456...
+```
+
+### Phase 2: Enable TLS for Services
+
+Update your module configurations with the fingerprint:
+
+```hcl
+module "grafana01" {
+  # ...
+  enable_tls         = true
+  stepca_url         = module.step_ca01.acme_endpoint
+  stepca_fingerprint = "abc123def456..."  # From Phase 1
+}
+
+module "prometheus01" {
+  # ...
+  enable_tls         = true
+  stepca_url         = module.step_ca01.acme_endpoint
+  stepca_fingerprint = "abc123def456..."
+}
+```
+
+Then re-deploy:
+
+```bash
+make deploy
+```
+
+## Certificate Lifecycle
+
+- **Duration**: 24 hours by default (configurable via `cert_duration`)
+- **Renewal**: Services automatically renew certificates on container restart
+- **Storage**: Certificates stored in `/etc/<service>/tls/` inside client containers
+- **Root CA**: Available at `/home/step/certs/root_ca.crt` in step-ca container
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `instance_name` | Name of the step-ca instance | `string` | n/a | yes |
+| `profile_name` | Name of the Incus profile | `string` | n/a | yes |
+| `profiles` | List of Incus profile names to apply | `list(string)` | `["default"]` | no |
+| `image` | Container image to use | `string` | `"ghcr:accuser/atlas/step-ca:latest"` | no |
+| `cpu_limit` | CPU limit (1-64) | `string` | `"1"` | no |
+| `memory_limit` | Memory limit (e.g., "512MB") | `string` | `"512MB"` | no |
+| `storage_pool` | Storage pool for the data volume | `string` | `"local"` | no |
+| `ca_name` | Name of the Certificate Authority | `string` | `"Atlas Internal CA"` | no |
+| `ca_dns_names` | Additional DNS names for CA certificate | `string` | `""` | no |
+| `ca_password` | Password for CA private keys | `string` | `""` | no |
+| `cert_duration` | Default certificate duration (e.g., "24h") | `string` | `"24h"` | no |
+| `enable_data_persistence` | Enable persistent storage | `bool` | `true` | no |
+| `data_volume_name` | Name of the storage volume | `string` | `"step-ca-data"` | no |
+| `data_volume_size` | Size of storage volume (min 100MB) | `string` | `"1GB"` | no |
+| `acme_port` | Port for ACME endpoint | `string` | `"9000"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `acme_endpoint` | ACME endpoint URL (e.g., `https://step-ca01.incus:9000`) |
+| `acme_directory` | Full ACME directory URL for clients |
+| `root_ca_path` | Path to root CA certificate in container |
+| `ca_name` | Name of the Certificate Authority |
+| `fingerprint_command` | Command to retrieve CA fingerprint |
+| `fingerprint_file_path` | Path to fingerprint file in container |
+
+## Troubleshooting
+
+### Check step-ca health
+
+```bash
+incus exec step-ca01 -- step ca health \
+  --ca-url https://localhost:9000 \
+  --root /home/step/certs/root_ca.crt
+```
+
+### View CA certificate details
+
+```bash
+incus exec step-ca01 -- step certificate inspect /home/step/certs/root_ca.crt
+```
+
+### Retrieve CA fingerprint
+
+```bash
+incus exec step-ca01 -- cat /home/step/fingerprint
+```
+
+### Test certificate request manually
+
+```bash
+incus exec step-ca01 -- step ca certificate test.local /tmp/test.crt /tmp/test.key \
+  --provisioner acme \
+  --ca-url https://localhost:9000
+```
+
+### View CA configuration
+
+```bash
+incus exec step-ca01 -- cat /home/step/config/ca.json
+```
+
+### Check CA logs
+
+```bash
+incus exec step-ca01 -- cat /home/step/logs/ca.log
+```
+
+### Verify ACME endpoint
+
+```bash
+# From another container on the management network
+curl -k https://step-ca01.incus:9000/acme/acme/directory
+```
+
+## DNS Names Configuration
+
+By default, the CA certificate includes:
+- `<instance_name>.incus` (e.g., `step-ca01.incus`)
+- `localhost`
+
+Add additional DNS names for the CA certificate:
+
+```hcl
+module "step_ca01" {
+  # ...
+  ca_dns_names = "step-ca.example.com,pki.internal"
+}
+```
+
+## Security Considerations
+
+1. **Protect the CA**: The step-ca container holds private keys; restrict access
+2. **Short-Lived Certificates**: 24-hour default reduces impact of key compromise
+3. **Persistent Storage**: CA data survives restarts but must be backed up
+4. **Fingerprint Trust**: Services verify the CA via its fingerprint (TOFU model)
+5. **Internal Only**: Run on management network, not publicly accessible
+
+## Backup and Recovery
+
+The CA data volume contains critical cryptographic material:
+
+```bash
+# Backup CA data
+incus storage volume snapshot local step-ca01-data backup-$(date +%Y%m%d)
+
+# List snapshots
+incus storage volume list local --format csv | grep step-ca
+
+# Restore from snapshot (requires container to be stopped)
+incus stop step-ca01
+incus storage volume restore local step-ca01-data backup-20240101
+incus start step-ca01
+```
+
+## Related Modules
+
+- [grafana](../grafana/) - Enable TLS for Grafana
+- [prometheus](../prometheus/) - Enable TLS for Prometheus
+- [loki](../loki/) - Enable TLS for Loki
+- [mosquitto](../mosquitto/) - Enable TLS for MQTT
+- [base-infrastructure](../base-infrastructure/) - Provides base profiles
+
+## References
+
+- [step-ca Documentation](https://smallstep.com/docs/step-ca)
+- [ACME Protocol](https://datatracker.ietf.org/doc/html/rfc8555)
+- [step CLI Reference](https://smallstep.com/docs/step-cli)
+- [Certificate Management Best Practices](https://smallstep.com/blog/everything-pki/)


### PR DESCRIPTION
## Summary

- Add comprehensive README documentation for all previously undocumented Terraform modules
- Each README follows the established pattern from caddy/grafana modules
- Includes usage examples, architecture diagrams, variables/outputs tables, and troubleshooting guides

## Modules Documented

| Module | Description |
|--------|-------------|
| alertmanager | Alert routing and notification management |
| base-infrastructure | Networks and reusable Incus profiles |
| cloudflared | Cloudflare Tunnel client for Zero Trust access |
| loki | Log aggregation system |
| mosquitto | MQTT broker with external access via proxy devices |
| node-exporter | Host-level metrics collection |
| prometheus | Metrics collection and time-series database |
| step-ca | Internal ACME Certificate Authority |

## Test plan

- [ ] Review README content for accuracy
- [ ] Verify code examples match actual module implementation
- [ ] Check all internal links work correctly

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)