### PR TITLE
feat: add automated snapshot scheduling to storage volumes

### DIFF
--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -4,14 +4,21 @@ resource "incus_storage_volume" "alertmanager_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for nobody user (UID 65534) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "65534"
-    "initial.gid"  = "65534"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for nobody user (UID 65534) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "65534"
+      "initial.gid"  = "65534"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/alertmanager/variables.tf
+++ b/terraform/modules/alertmanager/variables.tf
@@ -133,3 +133,38 @@ variable "cert_duration" {
     error_message = "Certificate duration must be in hours format (e.g., '24h', '168h')"
   }
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@daily"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "7d"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}

--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -4,14 +4,21 @@ resource "incus_storage_volume" "grafana_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for Grafana user (UID 472) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "472"
-    "initial.gid"  = "472"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for Grafana user (UID 472) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "472"
+      "initial.gid"  = "472"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -215,3 +215,38 @@ variable "enable_default_dashboards" {
   type        = bool
   default     = true
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@daily"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "7d"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -4,14 +4,21 @@ resource "incus_storage_volume" "loki_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for Loki user (UID 10001) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "10001"
-    "initial.gid"  = "10001"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for Loki user (UID 10001) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "10001"
+      "initial.gid"  = "10001"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -149,3 +149,38 @@ variable "retention_delete_delay" {
     error_message = "Retention delete delay must be in hours format (e.g., '2h')"
   }
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@weekly"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "2w"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}

--- a/terraform/modules/mosquitto/main.tf
+++ b/terraform/modules/mosquitto/main.tf
@@ -4,14 +4,21 @@ resource "incus_storage_volume" "mosquitto_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for mosquitto user (UID 1883) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "1883"
-    "initial.gid"  = "1883"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for mosquitto user (UID 1883) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "1883"
+      "initial.gid"  = "1883"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/mosquitto/variables.tf
+++ b/terraform/modules/mosquitto/variables.tf
@@ -183,3 +183,38 @@ variable "mosquitto_config" {
   type        = string
   default     = ""
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@daily"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "7d"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -4,14 +4,21 @@ resource "incus_storage_volume" "prometheus_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for Prometheus user (UID 65534/nobody) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "65534"
-    "initial.gid"  = "65534"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for Prometheus user (UID 65534/nobody) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "65534"
+      "initial.gid"  = "65534"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -176,3 +176,38 @@ variable "incus_metrics_private_key" {
   default     = ""
   sensitive   = true
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@weekly"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "2w"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}

--- a/terraform/modules/step-ca/main.tf
+++ b/terraform/modules/step-ca/main.tf
@@ -14,14 +14,21 @@ resource "incus_storage_volume" "step_ca_data" {
   name = var.data_volume_name
   pool = var.storage_pool
 
-  config = {
-    size = var.data_volume_size
-    # Set initial ownership for step user (UID 1000) to allow writes from non-root container
-    # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
-    "initial.uid"  = "1000"
-    "initial.gid"  = "1000"
-    "initial.mode" = "0755"
-  }
+  config = merge(
+    {
+      size = var.data_volume_size
+      # Set initial ownership for step user (UID 1000) to allow writes from non-root container
+      # Requires Incus 6.8+ (https://linuxcontainers.org/incus/news/2024_12_13_07_12.html)
+      "initial.uid"  = "1000"
+      "initial.gid"  = "1000"
+      "initial.mode" = "0755"
+    },
+    var.enable_snapshots ? {
+      "snapshots.schedule" = var.snapshot_schedule
+      "snapshots.expiry"   = var.snapshot_expiry
+      "snapshots.pattern"  = var.snapshot_pattern
+    } : {}
+  )
 
   content_type = "filesystem"
 }

--- a/terraform/modules/step-ca/variables.tf
+++ b/terraform/modules/step-ca/variables.tf
@@ -119,3 +119,38 @@ variable "acme_port" {
     error_message = "Port must be a number between 1 and 65535"
   }
 }
+
+# Snapshot Scheduling
+variable "enable_snapshots" {
+  description = "Enable automatic snapshots for the data volume"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression or shorthand (@hourly, @daily, @weekly) for snapshot schedule"
+  type        = string
+  default     = "@weekly"
+
+  validation {
+    condition     = can(regex("^(@(hourly|daily|weekly|monthly)|[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+\\s+[0-9*,/-]+)$", var.snapshot_schedule))
+    error_message = "Must be a valid cron expression or shorthand (@hourly, @daily, @weekly, @monthly)"
+  }
+}
+
+variable "snapshot_expiry" {
+  description = "How long to keep snapshots (e.g., 7d, 4w, 3m)"
+  type        = string
+  default     = "4w"
+
+  validation {
+    condition     = can(regex("^[0-9]+(d|w|m)$", var.snapshot_expiry))
+    error_message = "Must be in format like '7d' (days), '4w' (weeks), or '3m' (months)"
+  }
+}
+
+variable "snapshot_pattern" {
+  description = "Naming pattern for snapshots (supports {{creation_date}})"
+  type        = string
+  default     = "auto-{{creation_date}}"
+}


### PR DESCRIPTION
## Summary

- Add optional snapshot scheduling configuration to all 6 modules with persistent storage
- Snapshots are disabled by default - users opt-in when ready
- Uses Incus native scheduled snapshots (no external cron required)
- Updated BACKUP.md with Terraform-managed scheduling documentation

## Changes

**New variables added to modules:**
- `enable_snapshots` (bool, default: false)
- `snapshot_schedule` (string, default varies by service)
- `snapshot_expiry` (string, default varies by service)  
- `snapshot_pattern` (string, default: "auto-{{creation_date}}")

**Default schedules by criticality:**
| Service | Schedule | Retention |
|---------|----------|-----------|
| Grafana | @daily | 7d |
| Alertmanager | @daily | 7d |
| Mosquitto | @daily | 7d |
| Prometheus | @weekly | 2w |
| Loki | @weekly | 2w |
| step-ca | @weekly | 4w |

## Usage

```hcl
module "grafana01" {
  # ... existing config ...
  
  enable_snapshots   = true
  snapshot_schedule  = "@daily"
  snapshot_expiry    = "7d"
}
```

## Test plan

- [x] `tofu validate` passes
- [ ] CI checks pass
- [ ] Deploy with snapshots enabled on a test volume
- [ ] Verify snapshots are created on schedule

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)