### PR TITLE
feat: automate OCI remote configuration in bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1295,6 +1295,24 @@ These images are:
 - Extended from official images with custom plugins and configuration
 - Publicly accessible (no authentication required)
 
+**Image Reference Format (ghcr: vs ghcr.io/)**
+
+Terraform modules use `ghcr:` prefix (e.g., `ghcr:accuser/atlas/grafana:latest`) which references an **Incus remote** named "ghcr" that points to `https://ghcr.io`. This is not a typo - it's Incus-specific syntax.
+
+The bootstrap process (`make bootstrap`) automatically configures these OCI remotes:
+- `ghcr` → `https://ghcr.io` (GitHub Container Registry)
+- `docker` → `https://docker.io` (Docker Hub)
+
+You can verify remotes are configured with:
+```bash
+incus remote list
+```
+
+To manually add a remote (if not using bootstrap):
+```bash
+incus remote add ghcr https://ghcr.io --protocol=oci --public
+```
+
 **CI/CD Pipeline:**
 
 The pipeline is split into two workflows:

--- a/terraform/bootstrap/README.md
+++ b/terraform/bootstrap/README.md
@@ -5,11 +5,12 @@ This Terraform project bootstraps the prerequisites for the main Atlas infrastru
 ## Purpose
 
 The bootstrap project creates:
-1. Incus storage buckets configuration
-2. Storage pool for Terraform state
-3. Storage bucket for Terraform state
-4. S3 access credentials
-5. Backend configuration file for main project
+1. OCI remotes for container registries (ghcr, docker)
+2. Incus storage buckets configuration
+3. Storage pool for Terraform state
+4. Storage bucket for Terraform state
+5. S3 access credentials
+6. Backend configuration file for main project
 
 ## When to Use
 
@@ -161,19 +162,30 @@ tofu apply
 
 ## What It Creates
 
-### 1. Storage Buckets Configuration
+### 1. OCI Remotes
+Configures Incus remotes for pulling container images from OCI registries:
+- `ghcr` → `https://ghcr.io` (GitHub Container Registry)
+- `docker` → `https://docker.io` (Docker Hub)
+
+These enable pulling images using the `ghcr:` and `docker:` prefixes in Terraform:
+```hcl
+image = "ghcr:accuser/atlas/grafana:latest"  # Pulls from ghcr.io
+image = "docker:grafana/grafana:latest"      # Pulls from Docker Hub
+```
+
+### 2. Storage Buckets Configuration
 Sets `core.storage_buckets_address` in Incus to enable S3 API (default: `:8555`)
 
-### 2. Storage Pool
+### 3. Storage Pool
 Creates a storage pool named `terraform-state` (default driver: `dir`)
 
-### 3. Storage Bucket
+### 4. Storage Bucket
 Creates a bucket named `atlas-terraform-state` for Terraform state files
 
-### 4. S3 Credentials
+### 5. S3 Credentials
 Generates access key and secret key for S3 authentication
 
-### 5. Backend Configuration
+### 6. Backend Configuration
 Creates `terraform/backend.hcl` with:
 - Bucket name
 - Endpoint URL


### PR DESCRIPTION
## Summary

- Add automatic configuration of Incus OCI remotes during bootstrap process
- Document the `ghcr:` vs `ghcr.io/` image reference format

## Changes

### Bootstrap (`terraform/bootstrap/main.tf`)
- Add `null_resource.configure_oci_remotes` that configures:
  - `ghcr` → `https://ghcr.io` (GitHub Container Registry)
  - `docker` → `https://docker.io` (Docker Hub)
- Runs before storage bucket configuration
- Idempotent - skips if remotes already exist

### Documentation
- **CLAUDE.md**: Add "Image Reference Format" section explaining the `ghcr:` prefix is Incus-specific syntax referencing an Incus remote
- **terraform/bootstrap/README.md**: 
  - Update "Purpose" list to include OCI remotes
  - Add "OCI Remotes" section in "What It Creates"
  - Include example of how the prefixes work in Terraform

## Why This Change

The Terraform modules use `ghcr:accuser/atlas/grafana:latest` format which references an Incus remote named "ghcr". This was previously a manual prerequisite that could be missed. Now it's automated in bootstrap and clearly documented.

## Test plan

- [ ] Run `make bootstrap` on fresh Incus installation
- [ ] Verify `incus remote list` shows ghcr and docker remotes
- [ ] Verify `make deploy` successfully pulls images using `ghcr:` prefix
- [ ] Re-run bootstrap to verify idempotency (should skip existing remotes)

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)