### PR TITLE
docs: complete terraform.tfvars.example with all optional variables

### DIFF
--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -62,6 +62,40 @@ grafana_admin_password = "your-secure-grafana-password-here"
 # management_network_ipv6_nat = true
 
 # ============================================================================
+# OPTIONAL: CLOUDFLARE TUNNEL (Zero Trust)
+# ============================================================================
+# Enable secure remote access via Cloudflare Tunnel
+# Get token from: Cloudflare Zero Trust Dashboard -> Access -> Tunnels
+# Leave empty to disable Cloudflared deployment
+
+# cloudflared_tunnel_token = "eyJhIjoiYWJj..."  # Your tunnel token
+
+# ============================================================================
+# OPTIONAL: INCUS METRICS
+# ============================================================================
+# Configure scraping of Incus container metrics (CPU, memory, disk, network)
+# Metrics are collected via the Incus API with mTLS authentication
+
+# Enable/disable Incus metrics collection (default: true)
+# enable_incus_metrics = true
+
+# Incus API endpoint for metrics (default: management network gateway)
+# incus_metrics_address = "10.50.0.1:8443"
+
+# Server name for TLS verification (leave empty for self-signed certs)
+# If your Incus server has ACME configured, set this to its domain
+# incus_metrics_server_name = "incus.example.com"
+
+# ============================================================================
+# OPTIONAL: INCUS LOGGING TO LOKI
+# ============================================================================
+# Enable native Incus logging to Loki (lifecycle events, container logs)
+# This is a server-level configuration that sends events directly to Loki
+
+# Enable/disable Incus native logging to Loki (default: true)
+# enable_incus_loki = true
+
+# ============================================================================
 # USAGE INSTRUCTIONS
 # ============================================================================
 # 1. Copy this file: cp terraform.tfvars.example terraform.tfvars


### PR DESCRIPTION
## Summary

Add documentation for all optional configuration variables in `terraform/terraform.tfvars.example`, making it easier for users to discover and configure advanced features.

## New Sections Added

### Cloudflare Tunnel (Zero Trust)
- `cloudflared_tunnel_token` - Token for secure remote access via Cloudflare Tunnel
- Instructions on where to obtain the token

### Incus Metrics
- `enable_incus_metrics` - Enable/disable container metrics collection (default: true)
- `incus_metrics_address` - Incus API endpoint (default: management gateway)
- `incus_metrics_server_name` - Server name for TLS verification

### Incus Logging to Loki
- `enable_incus_loki` - Enable/disable native Incus logging (default: true)

## Format

Each section follows a consistent pattern:
- Clear section header with `=====` separators
- Description of what the feature does
- Where to obtain values (for tokens/secrets)
- Default values shown in comments
- Example values where helpful

## Test plan

- [x] Verify file is valid (no syntax errors in comments)
- [x] Confirm all variables from `variables.tf` are documented

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)