### PR TITLE
security: make allowed_ip_range a required variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1047,7 +1047,7 @@ module "grafana02" {
   network_name = incus_network.management.name
 
   domain           = "grafana-dev.accuser.dev"
-  allowed_ip_range = "192.168.68.0/22"
+  allowed_ip_range = "192.168.68.0/22"  # Required: Set to your network CIDR
 
   # Uses ghcr.io image by default (ghcr:accuser/atlas/grafana:latest)
   # Optional: Override to use official image
@@ -1362,7 +1362,7 @@ module "grafana01" {
 - The `terraform/terraform.tfvars` file is gitignored and must be created manually with required secrets
 - All services use custom images published to GitHub Container Registry (ghcr.io) by default
 - Images are automatically built and published by the Release workflow on push to main
-- Access to services is restricted to the 192.168.68.0/22 subnet by default
+- Access to services requires explicit `allowed_ip_range` configuration (no default for security)
 - All services use the `production` network for connectivity
 - Storage volumes use the `local` storage pool and are created automatically when modules are applied
 - Each module has a `versions.tf` specifying the Incus provider requirement

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -16,13 +16,14 @@ cloudflare_api_token = "your-cloudflare-api-token-here"
 # Generate a secure password: openssl rand -base64 16
 grafana_admin_password = "your-secure-grafana-password-here"
 
-# ============================================================================
-# ACCESS CONTROL
-# ============================================================================
 # IP range allowed to access public services (Grafana, etc.)
-# Set to your home/office network CIDR for security
-# Default: 0.0.0.0/0 (allow all - NOT recommended for production)
-# allowed_ip_range = "192.168.1.0/24"
+# REQUIRED: Set to your home/office network CIDR for security
+# Examples:
+#   - Single IP: "203.0.113.50/32"
+#   - Home network: "192.168.1.0/24"
+#   - Office range: "10.0.0.0/8"
+#   - Allow all (NOT recommended): "0.0.0.0/0"
+allowed_ip_range = "192.168.1.0/24"
 
 # ============================================================================
 # OPTIONAL NETWORK CONFIGURATION

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,9 +11,9 @@ variable "cloudflare_api_token" {
 
 # Access Control
 variable "allowed_ip_range" {
-  description = "IP range allowed to access public services (CIDR notation). Set to your home/office network for security, or 0.0.0.0/0 to allow all."
+  description = "IP range allowed to access public services (CIDR notation). Set to your home/office network for security. Required - no default for security reasons."
   type        = string
-  default     = "0.0.0.0/0"
+  # No default - must be explicitly set for security
 
   validation {
     condition     = can(cidrhost(var.allowed_ip_range, 0))


### PR DESCRIPTION
## Summary

- Remove insecure default (`0.0.0.0/0`) from `allowed_ip_range` variable
- Variable is now required - users must explicitly set their allowed IP range
- Update documentation and examples

## Breaking Change

This is a **BREAKING CHANGE** for existing deployments that rely on the default value. After this change, users must add `allowed_ip_range` to their `terraform.tfvars`:

```hcl
allowed_ip_range = "192.168.1.0/24"  # Your network CIDR
```

## Security Impact

- Prevents accidental exposure of Grafana and other services to the internet
- Forces users to make a conscious decision about access control
- Follows security best practice of "secure by default"

## Changes

| File | Change |
|------|--------|
| `terraform/variables.tf` | Remove default value, update description |
| `terraform/terraform.tfvars.example` | Add as required with examples |
| `CLAUDE.md` | Update documentation |

## Test plan

- [ ] Verify `tofu plan` fails without `allowed_ip_range` set
- [ ] Verify `tofu plan` succeeds with valid CIDR value
- [ ] Verify documentation is clear about requirement

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)