### PR TITLE
feat: add TLS configuration validation to modules

### DIFF
--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -106,4 +106,11 @@ resource "incus_instance" "alertmanager" {
     target_path = "/etc/alertmanager/alertmanager.yml"
     mode        = "0644"
   }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
+      error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
+    }
+  }
 }

--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -105,4 +105,11 @@ resource "incus_instance" "grafana" {
       mode        = "0644"
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
+      error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
+    }
+  }
 }

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -80,4 +80,11 @@ resource "incus_instance" "loki" {
     { for k, v in local.tls_env_vars : "environment.${k}" => v },
     { for k, v in local.retention_env_vars : "environment.${k}" => v if v != "" },
   )
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
+      error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
+    }
+  }
 }

--- a/terraform/modules/mosquitto/main.tf
+++ b/terraform/modules/mosquitto/main.tf
@@ -135,4 +135,11 @@ resource "incus_instance" "mosquitto" {
       mode        = "0644"
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
+      error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
+    }
+  }
 }

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -121,4 +121,11 @@ resource "incus_instance" "prometheus" {
       mode        = "0644"
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
+      error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add lifecycle preconditions to validate TLS configuration consistency
- When `enable_tls = true`, both `stepca_url` and `stepca_fingerprint` must be provided
- Errors are caught during `tofu plan` instead of at runtime

## Modules Updated

| Module | Validation Added |
|--------|------------------|
| grafana | ✅ |
| prometheus | ✅ |
| loki | ✅ |
| alertmanager | ✅ |
| mosquitto | ✅ |

## Validation Logic

```hcl
lifecycle {
  precondition {
    condition     = !var.enable_tls || (var.stepca_url != "" && var.stepca_fingerprint != "")
    error_message = "When enable_tls is true, both stepca_url and stepca_fingerprint must be provided."
  }
}
```

## Test plan

- [ ] Verify `tofu validate` passes
- [ ] Test with `enable_tls = true` and missing `stepca_url` - should fail plan
- [ ] Test with `enable_tls = true` and both values set - should pass
- [ ] Test with `enable_tls = false` - should pass regardless of other values

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)