### PR TITLE
fix(ci): add trivyignore for upstream CVE-2025-44005

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL
           ignore-unfixed: true
+          trivyignores: .trivyignore
 
       - name: Summary
         if: always()

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,17 @@
+# Trivy ignore file for known upstream vulnerabilities
+# These CVEs exist in upstream base images that we cannot directly fix.
+# We document them here and track upstream fixes.
+#
+# Format: CVE-ID  # reason
+# See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+
+# CVE-2025-44005: Step CA Has Authorization Bypass in ACME and SCEP
+# Affects: smallstep/certificates < v0.29.0
+# Status: Fixed in our step-ca image via PR #189 (bump to v0.29.0)
+# Impact: Other images (alertmanager, caddy, grafana, loki, mosquitto, prometheus)
+#         include this library through their upstream base images.
+#         We cannot fix this until upstream releases new versions.
+# Mitigation: Only step-ca uses ACME functionality in our deployment.
+#             The vulnerability is an authorization bypass, not RCE.
+# Track: https://github.com/smallstep/certificates/releases
+CVE-2025-44005


### PR DESCRIPTION
## Summary

- Add `.trivyignore` file to bypass CVE-2025-44005 in security scans
- Update CI workflow to use the trivyignore file

## Problem

CVE-2025-44005 (smallstep/certificates authorization bypass in ACME/SCEP) exists in many upstream base images we use:
- alertmanager
- caddy  
- grafana
- loki
- mosquitto
- prometheus

These images include the vulnerable smallstep/certificates library through their Go binaries. We cannot fix this until the upstream projects release new versions with the fix.

## Solution

Add a `.trivyignore` file that documents and ignores this specific CVE during security scans. This allows PRs to pass CI while we wait for upstream fixes.

## Notes

- The vulnerability IS fixed in our step-ca image via PR #189 (bump to v0.29.0)
- Only step-ca uses ACME functionality in our deployment
- The vulnerability is an authorization bypass, not RCE

## Test Plan

- [ ] CI passes with trivyignore in place
- [ ] Dependabot PRs can be merged after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)