### PR TITLE
refactor: rename docker-base to container-base and add root disk size limits

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,10 +55,10 @@ module "caddy01" {
   profile_name         = "caddy"
   cloudflare_api_token = var.cloudflare_api_token
 
-  # Profile composition - docker-base provides root disk and autorestart
-  # Caddy manages its own multi-network setup (production, management, external)
+  # Profile composition - container-base provides boot.autorestart
+  # Caddy module manages root disk with size limit and multi-network setup
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
   ]
 
   # Service blocks from all modules (production + management services only)
@@ -84,9 +84,10 @@ module "grafana01" {
   instance_name = "grafana01"
   profile_name  = "grafana"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
+  # Network profile provides NIC
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -136,9 +137,9 @@ module "loki01" {
   instance_name = "loki01"
   profile_name  = "loki"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -161,9 +162,9 @@ module "prometheus01" {
   instance_name = "prometheus01"
   profile_name  = "prometheus"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -284,9 +285,9 @@ module "step_ca01" {
   instance_name = "step-ca01"
   profile_name  = "step-ca"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -316,9 +317,9 @@ module "node_exporter01" {
   instance_name = "node-exporter01"
   profile_name  = "node-exporter"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -336,9 +337,9 @@ module "alertmanager01" {
   instance_name = "alertmanager01"
   profile_name  = "alertmanager"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -361,10 +362,10 @@ module "mosquitto01" {
   instance_name = "mosquitto01"
   profile_name  = "mosquitto"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   # Note: mosquitto uses production network for external access
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.production_network_profile.name,
   ]
 
@@ -399,10 +400,10 @@ module "coredns01" {
   instance_name = "coredns01"
   profile_name  = "coredns"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   # Note: coredns uses production network for LAN client access
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.production_network_profile.name,
   ]
 
@@ -444,9 +445,9 @@ module "cloudflared01" {
   instance_name = "cloudflared01"
   profile_name  = "cloudflared"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 
@@ -495,9 +496,9 @@ module "atlantis01" {
   instance_name = "atlantis01"
   profile_name  = "atlantis"
 
-  # Profile composition - docker-base provides root disk, network profile provides NIC
+  # Profile composition - container-base provides boot.autorestart, service profile provides root disk
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.gitops_network_profile.name,
   ]
 
@@ -534,10 +535,10 @@ module "caddy_gitops01" {
   profile_name         = "caddy-gitops"
   cloudflare_api_token = var.cloudflare_api_token
 
-  # Profile composition - docker-base provides root disk
-  # caddy-gitops module adds its own network NICs
+  # Profile composition - container-base provides boot.autorestart
+  # caddy-gitops module manages root disk with size limit and its own network NICs
   profiles = [
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
   ]
 
   # Service blocks - only Atlantis on this Caddy instance

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -24,8 +24,8 @@ resource "incus_storage_volume" "alertmanager_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "alertmanager" {
   name = var.profile_name
 
@@ -33,6 +33,17 @@ resource "incus_profile" "alertmanager" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   dynamic "device" {

--- a/terraform/modules/alertmanager/variables.tf
+++ b/terraform/modules/alertmanager/variables.tf
@@ -42,8 +42,19 @@ variable "storage_pool" {
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/atlantis/main.tf
+++ b/terraform/modules/atlantis/main.tf
@@ -20,8 +20,8 @@ resource "incus_storage_volume" "atlantis_data" {
 }
 
 # Service-specific profile
-# Contains resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits and service-specific devices (root disk with size limit, data volume)
+# Base infrastructure (network) is provided by profiles passed via var.profiles
 resource "incus_profile" "atlantis" {
   name = var.profile_name
 
@@ -29,6 +29,17 @@ resource "incus_profile" "atlantis" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # Data volume for persistent Atlantis data

--- a/terraform/modules/atlantis/variables.tf
+++ b/terraform/modules/atlantis/variables.tf
@@ -42,7 +42,7 @@ variable "memory_limit" {
 
 # Profile Composition
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profiles for network)"
   type        = list(string)
   default     = ["default"]
 }
@@ -51,6 +51,17 @@ variable "storage_pool" {
   description = "Storage pool for the data volume"
   type        = string
   default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
 }
 
 # Storage Configuration

--- a/terraform/modules/base-infrastructure/main.tf
+++ b/terraform/modules/base-infrastructure/main.tf
@@ -80,22 +80,14 @@ resource "incus_network" "gitops" {
 # Base Profiles
 # =============================================================================
 
-# Base profile for all Docker containers
-# Provides: boot.autorestart, root disk
-resource "incus_profile" "docker_base" {
-  name = "docker-base"
+# Base profile for all containers (OCI and system containers)
+# Provides: boot.autorestart only
+# Root disk is defined per-service module to allow size limits
+resource "incus_profile" "container_base" {
+  name = "container-base"
 
   config = {
     "boot.autorestart" = "true"
-  }
-
-  device {
-    name = "root"
-    type = "disk"
-    properties = {
-      path = "/"
-      pool = var.storage_pool
-    }
   }
 }
 

--- a/terraform/modules/base-infrastructure/outputs.tf
+++ b/terraform/modules/base-infrastructure/outputs.tf
@@ -39,9 +39,9 @@ output "management_network_gateway" {
 # =============================================================================
 # Full resource references for dependency tracking
 
-output "docker_base_profile" {
-  description = "Docker base profile resource (boot.autorestart, root disk)"
-  value       = incus_profile.docker_base
+output "container_base_profile" {
+  description = "Container base profile resource (boot.autorestart only)"
+  value       = incus_profile.container_base
 }
 
 output "production_network_profile" {

--- a/terraform/modules/caddy-gitops/main.tf
+++ b/terraform/modules/caddy-gitops/main.tf
@@ -3,7 +3,7 @@
 # Handles Atlantis webhook traffic with GitHub IP allowlisting
 
 # Service-specific profile
-# Contains resource limits and network configuration for GitOps traffic
+# Contains resource limits, root disk, and network configuration for GitOps traffic
 resource "incus_profile" "caddy_gitops" {
   name = var.profile_name
 
@@ -11,6 +11,17 @@ resource "incus_profile" "caddy_gitops" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # GitOps network (for Atlantis and CI/CD automation)

--- a/terraform/modules/caddy-gitops/variables.tf
+++ b/terraform/modules/caddy-gitops/variables.tf
@@ -42,9 +42,26 @@ variable "memory_limit" {
 }
 
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk)"
+  description = "List of Incus profile names to apply (root disk is managed by this module)"
   type        = list(string)
   default     = ["default"]
+}
+
+variable "storage_pool" {
+  description = "Storage pool for volumes"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
 }
 
 variable "gitops_network" {

--- a/terraform/modules/caddy/main.tf
+++ b/terraform/modules/caddy/main.tf
@@ -1,6 +1,6 @@
 # Service-specific profile
-# Contains only resource limits and service-specific devices (multi-network setup)
-# Base infrastructure (root disk, boot config) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices (multi-network setup)
+# Network is provided by profiles passed via var.profiles
 #
 # Network modes:
 # - Bridge mode (external_network set): 3 NICs - prod, mgmt, eth0 (external)
@@ -12,6 +12,17 @@ resource "incus_profile" "caddy" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # Caddy has a special multi-network setup for reverse proxy functionality

--- a/terraform/modules/caddy/variables.tf
+++ b/terraform/modules/caddy/variables.tf
@@ -37,9 +37,26 @@ variable "memory_limit" {
 }
 
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
+}
+
+variable "storage_pool" {
+  description = "Storage pool for the root disk"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
 }
 
 variable "production_network" {

--- a/terraform/modules/cloudflared/main.tf
+++ b/terraform/modules/cloudflared/main.tf
@@ -1,6 +1,6 @@
 # Service-specific profile
-# Contains only resource limits - base infrastructure (root disk, network) is
-# provided by profiles passed via var.profiles
+# Contains resource limits and root disk with size limit
+# Base infrastructure (network) is provided by profiles passed via var.profiles
 resource "incus_profile" "cloudflared" {
   name = var.profile_name
 
@@ -8,6 +8,17 @@ resource "incus_profile" "cloudflared" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 }
 

--- a/terraform/modules/cloudflared/variables.tf
+++ b/terraform/modules/cloudflared/variables.tf
@@ -36,8 +36,25 @@ variable "memory_limit" {
   }
 }
 
+variable "storage_pool" {
+  description = "Storage pool for volumes"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profiles for network)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/coredns/main.tf
+++ b/terraform/modules/coredns/main.tf
@@ -8,8 +8,8 @@
 # because LXC requires a proper filesystem structure that OCI containers lack.
 
 # Service-specific profile
-# Contains resource limits and service-specific devices (proxy devices for DNS)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices (proxy devices for DNS)
+# Network connectivity is provided by profiles passed via var.profiles
 resource "incus_profile" "coredns" {
   name = var.profile_name
 
@@ -18,6 +18,17 @@ resource "incus_profile" "coredns" {
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
     "boot.autostart"        = "true"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # External access via proxy device for DNS (UDP)

--- a/terraform/modules/coredns/variables.tf
+++ b/terraform/modules/coredns/variables.tf
@@ -40,8 +40,25 @@ variable "memory_limit" {
   }
 }
 
+variable "storage_pool" {
+  description = "Storage pool for volumes"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include docker-base and network profile)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = []
 }

--- a/terraform/modules/grafana/main.tf
+++ b/terraform/modules/grafana/main.tf
@@ -24,8 +24,8 @@ resource "incus_storage_volume" "grafana_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "grafana" {
   name = var.profile_name
 
@@ -35,6 +35,18 @@ resource "incus_profile" "grafana" {
     "limits.memory.enforce" = "hard"
   }
 
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
+  }
+
+  # Data volume for persistent storage
   dynamic "device" {
     for_each = var.enable_data_persistence ? [1] : []
     content {

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -37,13 +37,24 @@ variable "memory_limit" {
 }
 
 variable "storage_pool" {
-  description = "Storage pool for the data volume"
+  description = "Storage pool for volumes"
   type        = string
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -24,8 +24,8 @@ resource "incus_storage_volume" "loki_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "loki" {
   name = var.profile_name
 
@@ -33,6 +33,17 @@ resource "incus_profile" "loki" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   dynamic "device" {

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -42,8 +42,19 @@ variable "storage_pool" {
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/mosquitto/main.tf
+++ b/terraform/modules/mosquitto/main.tf
@@ -24,8 +24,8 @@ resource "incus_storage_volume" "mosquitto_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume, proxy devices)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "mosquitto" {
   name = var.profile_name
 
@@ -33,6 +33,17 @@ resource "incus_profile" "mosquitto" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # Persistent storage for MQTT data (retained messages, etc.)

--- a/terraform/modules/mosquitto/variables.tf
+++ b/terraform/modules/mosquitto/variables.tf
@@ -42,8 +42,19 @@ variable "storage_pool" {
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/node-exporter/main.tf
+++ b/terraform/modules/node-exporter/main.tf
@@ -2,8 +2,8 @@
 # Deploys Prometheus Node Exporter for host-level metrics collection
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (host mounts)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk, and service-specific devices (host mounts)
+# Base network infrastructure is provided by profiles passed via var.profiles
 resource "incus_profile" "node_exporter" {
   name = var.profile_name
 
@@ -11,6 +11,17 @@ resource "incus_profile" "node_exporter" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # Mount host filesystem read-only for metrics collection

--- a/terraform/modules/node-exporter/variables.tf
+++ b/terraform/modules/node-exporter/variables.tf
@@ -36,8 +36,25 @@ variable "memory_limit" {
   }
 }
 
+variable "storage_pool" {
+  description = "Storage pool for volumes"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profiles for network)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -24,8 +24,8 @@ resource "incus_storage_volume" "prometheus_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "prometheus" {
   name = var.profile_name
 
@@ -35,6 +35,18 @@ resource "incus_profile" "prometheus" {
     "limits.memory.enforce" = "hard"
   }
 
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
+  }
+
+  # Data volume for persistent storage
   dynamic "device" {
     for_each = var.enable_data_persistence ? [1] : []
     content {

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -37,13 +37,24 @@ variable "memory_limit" {
 }
 
 variable "storage_pool" {
-  description = "Storage pool for the data volume"
+  description = "Storage pool for volumes"
   type        = string
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "2GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }

--- a/terraform/modules/step-ca/main.tf
+++ b/terraform/modules/step-ca/main.tf
@@ -34,8 +34,8 @@ resource "incus_storage_volume" "step_ca_data" {
 }
 
 # Service-specific profile
-# Contains only resource limits and service-specific devices (data volume)
-# Base infrastructure (root disk, network) is provided by profiles passed via var.profiles
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
 resource "incus_profile" "step_ca" {
   name = var.profile_name
 
@@ -43,6 +43,17 @@ resource "incus_profile" "step_ca" {
     "limits.cpu"            = var.cpu_limit
     "limits.memory"         = var.memory_limit
     "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
   }
 
   # Mount persistent volume for CA data

--- a/terraform/modules/step-ca/variables.tf
+++ b/terraform/modules/step-ca/variables.tf
@@ -42,8 +42,19 @@ variable "storage_pool" {
   default     = "local"
 }
 
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "1GB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
 variable "profiles" {
-  description = "List of Incus profile names to apply (should include base profiles for root disk and network)"
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
   type        = list(string)
   default     = ["default"]
 }


### PR DESCRIPTION
## Summary

- Rename `docker-base` profile to `container-base` (more accurate naming since it's used for both OCI and system containers like CoreDNS)
- Move root disk device from base profile to each service module's profile
- Add `root_disk_size` variable to all 12 service modules with sensible defaults

## Changes

### Base Infrastructure
- Renamed profile from `docker-base` to `container-base`
- Removed root disk device (now per-module)
- Profile now only provides `boot.autorestart = true`

### Service Modules (all 12 updated)
Each module now has:
- `root_disk_size` variable with validation
- Root disk device in its profile with size limit

| Module | Default Size |
|--------|-------------|
| alertmanager | 1GB |
| atlantis | 2GB |
| caddy | 1GB |
| caddy-gitops | 1GB |
| cloudflared | 1GB |
| coredns | 1GB |
| grafana | 2GB |
| loki | 2GB |
| mosquitto | 1GB |
| node-exporter | 1GB |
| prometheus | 2GB |
| step-ca | 1GB |

## Rationale

1. **Naming accuracy**: `container-base` better reflects that the profile is used for both OCI containers and system containers (like CoreDNS using Alpine cloud image)

2. **DoS prevention**: Previously containers had unlimited storage, which could lead to denial of service if a container fills up the host storage pool

3. **Finer-grained control**: Each service can now have its own appropriate storage limit rather than a one-size-fits-all approach

## Test plan

- [x] `tofu validate` passes
- [x] `tofu fmt` applied
- [ ] Deploy to test environment
- [ ] Verify containers start with correct disk limits (`incus config show <container>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)