### PR TITLE
docs: update documentation for container-base profile rename

### DIFF
--- a/terraform/modules/alertmanager/README.md
+++ b/terraform/modules/alertmanager/README.md
@@ -21,8 +21,7 @@ module "alertmanager01" {
   profile_name  = "alertmanager"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 

--- a/terraform/modules/cloudflared/README.md
+++ b/terraform/modules/cloudflared/README.md
@@ -22,8 +22,7 @@ module "cloudflared01" {
   profile_name  = "cloudflared"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 

--- a/terraform/modules/loki/README.md
+++ b/terraform/modules/loki/README.md
@@ -21,8 +21,7 @@ module "loki01" {
   profile_name  = "loki"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 

--- a/terraform/modules/mosquitto/README.md
+++ b/terraform/modules/mosquitto/README.md
@@ -21,8 +21,7 @@ module "mosquitto01" {
   profile_name  = "mosquitto"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.production_network_profile.name,
   ]
 

--- a/terraform/modules/node-exporter/README.md
+++ b/terraform/modules/node-exporter/README.md
@@ -20,8 +20,7 @@ module "node_exporter01" {
   profile_name  = "node-exporter"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 }

--- a/terraform/modules/prometheus/README.md
+++ b/terraform/modules/prometheus/README.md
@@ -22,8 +22,7 @@ module "prometheus01" {
   profile_name  = "prometheus"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 

--- a/terraform/modules/step-ca/README.md
+++ b/terraform/modules/step-ca/README.md
@@ -21,8 +21,7 @@ module "step_ca01" {
   profile_name  = "step-ca"
 
   profiles = [
-    "default",
-    module.base.docker_base_profile.name,
+    module.base.container_base_profile.name,
     module.base.management_network_profile.name,
   ]
 


### PR DESCRIPTION
## Summary

Update all documentation to reflect the profile rename from `docker-base` to `container-base` and the new root disk architecture introduced in #207.

## Changes

### CLAUDE.md
- Updated profile composition examples to use `container_base_profile`
- Updated profile descriptions (container-base now only provides `boot.autorestart`)
- Added documentation about root disk management by service modules
- Updated design principles section

### base-infrastructure/README.md
- Updated features list
- Updated architecture diagram to show container-base profile
- Updated profile composition pattern explanation
- Updated outputs table
- Updated troubleshooting commands (`incus profile show container-base`)

### Module READMEs (7 modules)
Updated profile composition examples in:
- alertmanager
- cloudflared
- loki
- mosquitto
- node-exporter
- prometheus
- step-ca

## Test plan

- [x] No code changes, documentation only
- [x] Verified no remaining `docker-base` or `docker_base` references in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)