### PR TITLE
feat(promtail): add Promtail module for log shipping to central Loki

### DIFF
--- a/environments/cluster/main.tf
+++ b/environments/cluster/main.tf
@@ -284,20 +284,24 @@ module "incus_metrics" {
 # =============================================================================
 # Log Shipping (Promtail)
 # =============================================================================
-# TODO: Create promtail module in Phase 3
-# module "promtail01" {
-#   source = "../../modules/promtail"
-#
-#   instance_name = "promtail01"
-#   profile_name  = "promtail"
-#
-#   profiles = [
-#     module.base.container_base_profile.name,
-#     module.base.management_network_profile.name,
-#   ]
-#
-#   loki_push_url = var.loki_push_url
-#
-#   cpu_limit    = local.services.promtail.cpu
-#   memory_limit = local.services.promtail.memory
-# }
+
+module "promtail01" {
+  source = "../../modules/promtail"
+
+  instance_name = "promtail01"
+  profile_name  = "promtail"
+
+  profiles = [
+    module.base.container_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  loki_push_url = var.loki_push_url
+
+  extra_labels = {
+    environment = "cluster"
+  }
+
+  cpu_limit    = local.services.promtail.cpu
+  memory_limit = local.services.promtail.memory
+}

--- a/environments/cluster/outputs.tf
+++ b/environments/cluster/outputs.tf
@@ -82,3 +82,17 @@ output "incus_metrics_certificate_fingerprint" {
   description = "Fingerprint of the metrics certificate"
   value       = var.enable_incus_metrics ? module.incus_metrics[0].certificate_fingerprint : null
 }
+
+# =============================================================================
+# Log Shipping
+# =============================================================================
+
+output "promtail_endpoint" {
+  description = "Promtail HTTP API endpoint URL"
+  value       = module.promtail01.promtail_endpoint
+}
+
+output "promtail_loki_target" {
+  description = "Loki URL that Promtail is shipping logs to"
+  value       = module.promtail01.loki_push_url
+}

--- a/modules/promtail/README.md
+++ b/modules/promtail/README.md
@@ -1,0 +1,90 @@
+# Promtail Module
+
+This module deploys Promtail as a log shipping agent that forwards logs to a central Loki instance.
+
+## Overview
+
+Promtail is deployed as an Alpine Linux system container with cloud-init configuration. It scrapes local logs and ships them to a remote Loki instance.
+
+## Usage
+
+```hcl
+module "promtail01" {
+  source = "../../modules/promtail"
+
+  instance_name = "promtail01"
+  profile_name  = "promtail"
+
+  loki_push_url = "http://loki01.iapetus:3100/loki/api/v1/push"
+
+  profiles = [
+    module.base.container_base_profile.name,
+    module.base.management_network_profile.name,
+  ]
+
+  extra_labels = {
+    environment = "cluster"
+    datacenter  = "home"
+  }
+}
+```
+
+## Cross-Environment Log Shipping
+
+This module is designed for shipping logs from one Incus environment to another:
+
+```
+cluster (production workloads)     iapetus (control plane)
+┌─────────────────────────┐        ┌─────────────────────────┐
+│  promtail01             │───────>│  loki01                 │
+│  (scrapes local logs)   │  HTTP  │  (aggregates all logs)  │
+└─────────────────────────┘        └─────────────────────────┘
+```
+
+## Variables
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `instance_name` | Name of the Promtail instance | `string` | - |
+| `profile_name` | Name of the Incus profile | `string` | - |
+| `loki_push_url` | URL of Loki push endpoint | `string` | - |
+| `promtail_version` | Version of Promtail to install | `string` | `3.3.2` |
+| `cpu_limit` | CPU limit for container | `string` | `1` |
+| `memory_limit` | Memory limit for container | `string` | `256MB` |
+| `extra_labels` | Additional labels for log entries | `map(string)` | `{}` |
+| `target_node` | Cluster node to pin instance to | `string` | `""` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_name` | Name of the created instance |
+| `promtail_endpoint` | HTTP API endpoint URL |
+| `ipv4_address` | IPv4 address of the instance |
+| `loki_push_url` | Configured Loki push URL |
+
+## Log Sources
+
+By default, Promtail scrapes:
+
+1. **Journal logs** - System journal entries (syslog_identifier, unit, level)
+2. **System logs** - Files matching `/var/log/*.log`
+
+## Labels
+
+All log entries include:
+- `host` - The Promtail instance name
+- `job` - Either `journal` or `system`
+- Any labels from `extra_labels` variable
+
+## Resource Requirements
+
+| Resource | Default | Minimum |
+|----------|---------|---------|
+| CPU | 1 core | 1 core |
+| Memory | 256MB | 128MB |
+| Disk | 512MB | 256MB |
+
+## Network Requirements
+
+Promtail requires outbound HTTP/HTTPS access to the Loki instance. Ensure the management network can route to the Loki endpoint.

--- a/modules/promtail/main.tf
+++ b/modules/promtail/main.tf
@@ -1,0 +1,58 @@
+# =============================================================================
+# Promtail Module
+# =============================================================================
+# Log shipping agent for sending logs to a central Loki instance
+# Uses Alpine Linux system container with cloud-init for configuration
+
+locals {
+  # Cloud-init configuration
+  cloud_init_content = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
+    promtail_version = var.promtail_version
+    promtail_port    = var.promtail_port
+    loki_push_url    = var.loki_push_url
+    hostname         = var.instance_name
+    extra_labels     = var.extra_labels
+  })
+}
+
+# Service-specific profile
+# Contains resource limits, root disk with size limit, and service-specific devices
+# Network is provided by profiles passed via var.profiles
+resource "incus_profile" "promtail" {
+  name = var.profile_name
+
+  config = {
+    "limits.cpu"            = var.cpu_limit
+    "limits.memory"         = var.memory_limit
+    "limits.memory.enforce" = "hard"
+  }
+
+  # Root disk with size limit
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = var.storage_pool
+      size = var.root_disk_size
+    }
+  }
+}
+
+resource "incus_instance" "promtail" {
+  name     = var.instance_name
+  image    = var.image
+  type     = "container"
+  profiles = concat(var.profiles, [incus_profile.promtail.name])
+
+  # Pin to specific cluster node if specified
+  target = var.target_node != "" ? var.target_node : null
+
+  config = {
+    "cloud-init.user-data" = local.cloud_init_content
+  }
+
+  depends_on = [
+    incus_profile.promtail
+  ]
+}

--- a/modules/promtail/outputs.tf
+++ b/modules/promtail/outputs.tf
@@ -1,0 +1,29 @@
+output "instance_name" {
+  description = "Name of the created Promtail instance"
+  value       = incus_instance.promtail.name
+}
+
+output "profile_name" {
+  description = "Name of the created profile"
+  value       = incus_profile.promtail.name
+}
+
+output "instance_status" {
+  description = "Status of the created Promtail instance"
+  value       = incus_instance.promtail.status
+}
+
+output "promtail_endpoint" {
+  description = "Promtail HTTP API endpoint URL (using .incus DNS)"
+  value       = "http://${var.instance_name}.incus:${var.promtail_port}"
+}
+
+output "ipv4_address" {
+  description = "IPv4 address of the Promtail instance"
+  value       = incus_instance.promtail.ipv4_address
+}
+
+output "loki_push_url" {
+  description = "Configured Loki push URL"
+  value       = var.loki_push_url
+}

--- a/modules/promtail/templates/cloud-init.yaml.tftpl
+++ b/modules/promtail/templates/cloud-init.yaml.tftpl
@@ -1,0 +1,108 @@
+#cloud-config
+# Promtail system container configuration
+# Uses Alpine Linux with OpenRC service management
+
+package_update: true
+
+packages:
+  - curl
+  - unzip
+
+write_files:
+  # Promtail configuration file
+  - path: /etc/promtail/promtail-config.yaml
+    permissions: '0644'
+    content: |
+      # Promtail configuration
+      server:
+        http_listen_port: ${promtail_port}
+        grpc_listen_port: 0
+
+      positions:
+        filename: /var/lib/promtail/positions.yaml
+
+      clients:
+        - url: ${loki_push_url}
+
+      scrape_configs:
+        # Scrape container logs from journal
+        - job_name: journal
+          journal:
+            max_age: 12h
+            labels:
+              job: systemd-journal
+              host: ${hostname}
+%{ for key, value in extra_labels ~}
+              ${key}: ${value}
+%{ endfor ~}
+          relabel_configs:
+            - source_labels: ['__journal_syslog_identifier']
+              target_label: 'syslog_identifier'
+            - source_labels: ['__journal__systemd_unit']
+              target_label: 'unit'
+            - source_labels: ['__journal_priority_keyword']
+              target_label: 'level'
+
+        # Scrape system logs
+        - job_name: system
+          static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: system
+                host: ${hostname}
+%{ for key, value in extra_labels ~}
+                ${key}: ${value}
+%{ endfor ~}
+                __path__: /var/log/*.log
+
+  # OpenRC init script for Promtail
+  - path: /etc/init.d/promtail
+    permissions: '0755'
+    content: |
+      #!/sbin/openrc-run
+
+      name="promtail"
+      description="Promtail log shipping agent"
+      command="/usr/local/bin/promtail"
+      command_args="-config.file=/etc/promtail/promtail-config.yaml"
+      command_background=true
+      command_user="promtail"
+      pidfile="/run/$${RC_SVCNAME}.pid"
+      output_log="/var/log/promtail.log"
+      error_log="/var/log/promtail.log"
+
+      depend() {
+        need net
+        after firewall
+      }
+
+      start_pre() {
+        # Ensure promtail user owns required directories
+        chown -R promtail:promtail /var/lib/promtail 2>/dev/null || true
+        chown -R promtail:promtail /etc/promtail 2>/dev/null || true
+      }
+
+runcmd:
+  # Download and install Promtail
+  - |
+    PROMTAIL_VERSION="${promtail_version}"
+    cd /tmp
+    curl -sLO "https://github.com/grafana/loki/releases/download/v$${PROMTAIL_VERSION}/promtail-linux-amd64.zip"
+    unzip -o "promtail-linux-amd64.zip"
+    mv promtail-linux-amd64 /usr/local/bin/promtail
+    chmod +x /usr/local/bin/promtail
+    rm -f "promtail-linux-amd64.zip"
+  # Create promtail user and directories
+  - addgroup -g 10001 promtail 2>/dev/null || true
+  - adduser -D -u 10001 -G promtail -H -s /sbin/nologin promtail 2>/dev/null || true
+  - mkdir -p /var/lib/promtail /etc/promtail
+  - chown -R promtail:promtail /var/lib/promtail /etc/promtail
+  # Create log file with proper permissions
+  - touch /var/log/promtail.log
+  - chown promtail:promtail /var/log/promtail.log
+  # Allow promtail to read system logs
+  - chmod 644 /var/log/*.log 2>/dev/null || true
+  # Enable and start promtail service
+  - rc-update add promtail default
+  - rc-service promtail start

--- a/modules/promtail/variables.tf
+++ b/modules/promtail/variables.tf
@@ -1,0 +1,99 @@
+variable "instance_name" {
+  description = "Name of the Promtail instance"
+  type        = string
+}
+
+variable "profile_name" {
+  description = "Name of the Incus profile"
+  type        = string
+}
+
+variable "image" {
+  description = "Container image to use (system container with cloud-init)"
+  type        = string
+  default     = "images:alpine/3.21/cloud"
+}
+
+variable "promtail_version" {
+  description = "Version of Promtail to install"
+  type        = string
+  default     = "3.3.2"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the container"
+  type        = string
+  default     = "1"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.cpu_limit)) && tonumber(var.cpu_limit) >= 1 && tonumber(var.cpu_limit) <= 64
+    error_message = "CPU limit must be a number between 1 and 64"
+  }
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the container"
+  type        = string
+  default     = "256MB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.memory_limit))
+    error_message = "Memory limit must be in format like '256MB' or '1GB'"
+  }
+}
+
+variable "storage_pool" {
+  description = "Storage pool for the root disk"
+  type        = string
+  default     = "local"
+}
+
+variable "root_disk_size" {
+  description = "Size limit for the root disk (container filesystem)"
+  type        = string
+  default     = "512MB"
+
+  validation {
+    condition     = can(regex("^[0-9]+(MB|GB)$", var.root_disk_size))
+    error_message = "Root disk size must be in format like '1GB' or '500MB'"
+  }
+}
+
+variable "profiles" {
+  description = "List of Incus profile names to apply (should include base profile and network profile)"
+  type        = list(string)
+  default     = ["default"]
+}
+
+variable "promtail_port" {
+  description = "Port that Promtail listens on for HTTP API"
+  type        = string
+  default     = "9080"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.promtail_port)) && tonumber(var.promtail_port) >= 1 && tonumber(var.promtail_port) <= 65535
+    error_message = "Port must be a number between 1 and 65535"
+  }
+}
+
+variable "loki_push_url" {
+  description = "URL of the Loki instance to push logs to (e.g., http://loki01.iapetus:3100/loki/api/v1/push)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^https?://", var.loki_push_url))
+    error_message = "Loki push URL must start with http:// or https://"
+  }
+}
+
+variable "extra_labels" {
+  description = "Additional labels to attach to all log entries"
+  type        = map(string)
+  default     = {}
+}
+
+variable "target_node" {
+  description = "Target cluster node to pin this instance to (for cluster deployments)"
+  type        = string
+  default     = ""
+}

--- a/modules/promtail/versions.tf
+++ b/modules/promtail/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">= 0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `modules/promtail/` for shipping logs from cluster environment to iapetus Loki
- Uses Alpine Linux system container with cloud-init (consistent with other modules)
- Enables Promtail in cluster environment

## Architecture

```
cluster environment                iapetus environment
┌─────────────────────┐           ┌─────────────────────┐
│  promtail01         │──HTTP────>│  loki01             │
│  (scrapes logs)     │           │  (aggregates logs)  │
└─────────────────────┘           └─────────────────────┘
```

## Changes

### New Module: `modules/promtail/`
- `main.tf` - Instance and profile resources
- `variables.tf` - Configuration variables (loki_push_url, extra_labels, etc.)
- `outputs.tf` - Endpoint and status outputs
- `templates/cloud-init.yaml.tftpl` - Alpine + Promtail setup
- `README.md` - Usage documentation

### Cluster Environment Updates
- Enable promtail01 module in main.tf
- Add promtail outputs (endpoint, loki target)

## Log Sources
Promtail scrapes:
- Journal logs (syslog_identifier, unit, level labels)
- System logs (`/var/log/*.log`)

## Test plan
- [x] `tofu validate` passes for environments/cluster
- [x] `tofu validate` passes for environments/iapetus
- [ ] CI validates both environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)